### PR TITLE
Better Linux support - Wine/Proton fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ Code.pul
 # Build output
 /build/
 /build-*/
-/native-build/
+/*native-build/
 /dist/
 /extracted/
 /out/

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,11 @@ Code.pul
 # Build output
 /build/
 /build-*/
+/native-build/
 /dist/
+/extracted/
 /out/
+/.toolchain/
 [Bb]in/
 [Oo]bj/
 *.o
@@ -55,6 +58,7 @@ project.lock.json
 /Launcher/dist/
 /Launcher/WiiCompiled-Setup.exe
 *.exe
+Mario Kart Wii*
 *.msi
 
 
@@ -62,10 +66,12 @@ project.lock.json
 /.vs/
 /.vscode/
 /.idea/
+/.zed/
 /tools/
 /TEMP/
 /tmp/
 /test_output/
 *.log
+.claude
+.clang-format
 output.txt
-

--- a/runtime/include/abi_bridge.h
+++ b/runtime/include/abi_bridge.h
@@ -639,7 +639,11 @@ inline void InvokeIndirectJump(uint32_t target, CpuContext* ctx) {
 inline void InvokeIndirectCpu(uint32_t target, CpuContext* ctx) {
     CpuContext* cpu = ctx ? ctx : &GetPersistentCpuContext();
     if (target == 0) {
-        ReportMissingCpuTarget(target, cpu);
+        // A call through address 0 is a virtual dispatch through a null "this",
+        // not a missing translator target, so skip it instead of crashing.
+        RT_LOG(RT_TAG_RUNTIME) << "InvokeIndirectCpu: skipped a virtual call through a null "
+            "object pointer (caller LR=0x" << std::hex << cpu->lr << std::dec << ")" << std::endl;
+        return;
     }
     ApplyRuntimeCallOptions(target, cpu);
     if (TryDispatchRawCpuTarget(TranslatedFunctionRegistry::FindRawByAddressPtr(target), cpu)) {

--- a/runtime/include/host_platform.h
+++ b/runtime/include/host_platform.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
+// The runtime always targets Windows, but here we detect if we're running
+// under Wine/Proton on Linux. Here we can edit certain features (such as
+// removing exclusive fullscreen)
+namespace RuntimeHostPlatform {
+
+// True when running under Wine/Proton, detected
+// via Wine's ntdll.dll exports wine_get_version
+inline bool IsRunningUnderWine() noexcept {
+#ifdef _WIN32
+    static const bool result = [] {
+        const HMODULE ntdll = ::GetModuleHandleW(L"ntdll.dll");
+        if (ntdll == nullptr) {
+            return false;
+        }
+        return ::GetProcAddress(ntdll, "wine_get_version") != nullptr;
+    }();
+    return result;
+#else
+    return false;
+#endif
+}
+
+} // namespace RuntimeHostPlatform

--- a/runtime/include/runtime_config.h
+++ b/runtime/include/runtime_config.h
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 #include <toml.hpp>
+#include "host_platform.h"
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -130,6 +131,16 @@ inline bool IsSupportedDisplayMode(std::string_view value) {
         "windowed", "borderless", "exclusive",
     };
     return std::find(values.begin(), values.end(), value) != values.end();
+}
+
+// Remove Exclusive fullscreen on Wine/Proton
+inline std::string EffectiveDisplayMode(std::string value) {
+    if (value == "exclusive" && RuntimeHostPlatform::IsRunningUnderWine()) {
+        std::cerr << "[runtime] video.display_mode=\"exclusive\" is unreliable under Wine/Proton; "
+                     "using \"borderless\" instead" << std::endl;
+        return "borderless";
+    }
+    return value;
 }
 
 // 240 was offered by an early build and is no longer supported; a saved 240 is
@@ -347,7 +358,7 @@ inline RuntimeUserConfig ParseConfigDocument(const toml::value& document) {
     }
     if (auto value = FindConfigValue<std::string>(document, "video", "display_mode");
         value && IsSupportedDisplayMode(*value)) {
-        config.displayMode = *value;
+        config.displayMode = EffectiveDisplayMode(*value);
     }
     if (auto value = FindConfigUint(document, "video", "frame_interpolation_fps")) {
         const uint32_t migrated = *value == 240u ? 180u : *value;
@@ -552,6 +563,7 @@ inline bool SetDisplayMode(std::string value) {
     if (!IsSupportedDisplayMode(value)) {
         return false;
     }
+    value = EffectiveDisplayMode(std::move(value));
     Mutable().displayMode = value;
     return WriteSetting("video", "display_mode", FormatString(value));
 }

--- a/runtime/include/runtime_config.h
+++ b/runtime/include/runtime_config.h
@@ -232,10 +232,6 @@ inline void EnsureConfigFile() {
               "resolution_multiplier = 1.0\n"
               "frame_interpolation_fps = 0\n"
               "display_mode = \"windowed\"\n"
-              // "auto" itself is Wine-aware: see the backend resolution in
-              // main.cpp's RuntimeMain, which tries Vulkan first under Wine/
-              // Proton instead of D3D12 (whose Wine/vkd3d support is commonly
-              // incomplete) and leaves real Windows unaffected.
               "graphics_api = \"auto\"\n"
               "skip_unready_pipelines = true\n"
               "disable_copy_filter = true\n"

--- a/runtime/include/runtime_config.h
+++ b/runtime/include/runtime_config.h
@@ -232,6 +232,10 @@ inline void EnsureConfigFile() {
               "resolution_multiplier = 1.0\n"
               "frame_interpolation_fps = 0\n"
               "display_mode = \"windowed\"\n"
+              // "auto" itself is Wine-aware: see the backend resolution in
+              // main.cpp's RuntimeMain, which tries Vulkan first under Wine/
+              // Proton instead of D3D12 (whose Wine/vkd3d support is commonly
+              // incomplete) and leaves real Windows unaffected.
               "graphics_api = \"auto\"\n"
               "skip_unready_pipelines = true\n"
               "disable_copy_filter = true\n"

--- a/runtime/src/hle/retro_rewind_page_guard.cpp
+++ b/runtime/src/hle/retro_rewind_page_guard.cpp
@@ -1,0 +1,100 @@
+#include "hle_stubs.h"
+#include "memory.h"
+#include "ppc_runtime.h"
+#include "runtime_log.h"
+
+#include <cstdint>
+
+// Retro Rewind's Kamek patch at 0x8185DC30 resolves a pause-menu page by
+// index (0-255 from the table at +8, 256-511 from the extended table at
+// +1032) and activates it. On Wine/Proton and native Linux, page index 0x19
+// resolves to a null pointer; the original patch calls Page::Activate on it
+// with no null check, which crashes several calls deep with "missing
+// indirect jump target".
+//
+// This is a faithful reimplementation of that translated function (verified
+// against generated/build_shards/retro_mod's own output for 0x8185DC30),
+// with one behavioral change: when the resolved page is null, skip
+// Page::Activate and the page->+16 write before it, matching
+// InvokeIndirectCpu's null-target handling (abi_bridge.h) instead of
+// crashing.
+extern "C" void func_80601AEC(CpuContext* ctx); // Page::Activate
+
+extern "C" void RetroRewind_ActivatePageByIndex_NullGuarded(CpuContext* ctx)
+{
+    uint32_t r1 = ctx->gpr[1];
+    const uint32_t manager = ctx->gpr[3];
+    const uint32_t index = ctx->gpr[4];
+    uint32_t subIndex = ctx->gpr[5];
+    const uint32_t callerR31 = ctx->gpr[31];
+    uint32_t cr = ctx->cr;
+    const uint32_t xer = ctx->xer;
+
+    // Prologue: push a 16-byte stack frame, save LR and the caller's r31.
+    MemoryInline::FlatWriteRam32(r1 - 16, r1);
+    r1 = r1 - 16;
+    const uint32_t savedLr = ctx->lr;
+    MemoryInline::FlatWriteRam32(r1 + 20, savedLr);
+    MemoryInline::FlatWriteRam32(r1 + 12, callerR31);
+
+    if (subIndex == 255u) {
+        subIndex = MemoryInline::FlatRead32(manager + 4);
+    }
+
+    uint32_t page;
+    if (index < 256u) {
+        page = MemoryInline::FlatRead32(manager + (index * 4u) + 8);
+    } else {
+        page = MemoryInline::FlatRead32(manager + ((index - 256u) * 4u) + 1032);
+    }
+
+    if (page == 0) {
+        // Also skip the page-stack push below: pushing a null entry just moves
+        // the crash to Section::Update, which walks that stack every frame.
+        RT_LOG(RT_TAG_OS) << "Retro Rewind: page index 0x" << std::hex << index
+            << " has no registered page (table slot is null); "
+               "skipping it entirely instead of crashing." << std::dec << std::endl;
+        // Dump populated page-table slots for diagnostics.
+        RT_LOG(RT_TAG_OS) << "Retro Rewind: manager=0x" << std::hex << manager
+            << " page table dump (index=pointer, only non-null shown):" << std::dec << std::endl;
+        for (uint32_t i = 0; i < 64u; ++i) {
+            const uint32_t slot = MemoryInline::FlatRead32(manager + (i * 4u) + 8);
+            if (slot != 0) {
+                RT_LOG(RT_TAG_OS) << "  [" << i << "]=0x" << std::hex << slot << std::dec << std::endl;
+            }
+        }
+    } else {
+        uint32_t counter = MemoryInline::FlatRead32(manager + 892);
+        const uint32_t compareValue = subIndex + 65536u;
+        SetCRResident(cr, xer, 0, compareValue, 65535u);
+
+        counter = counter + 1u;
+        MemoryInline::FlatWrite32(manager + 892, counter);
+        MemoryInline::FlatWrite32(manager + (counter * 4u) + 848, page);
+        if ((cr & 0x20000000u) == 0) {
+            MemoryInline::FlatWrite32(page + 16, subIndex);
+        }
+
+        ctx->lr = 0x8185DCA4u;
+        ctx->gpr[1] = r1;
+        ctx->gpr[3] = page;
+        ctx->gpr[4] = index;
+        ctx->gpr[5] = subIndex;
+        ctx->gpr[31] = page;
+        ctx->cr = cr;
+        func_80601AEC(ctx); // Page::Activate(page)
+        page = ctx->gpr[31]; // Activate leaves r31 callee-saved as the page
+    }
+
+    // Epilogue: restore the caller's r31/LR, pop the stack frame, and return
+    // the resolved page pointer (possibly null) in r3, matching the original.
+    ctx->lr = savedLr;
+    ctx->gpr[0] = savedLr;
+    ctx->gpr[1] = r1 + 16;
+    ctx->gpr[3] = page;
+    ctx->gpr[4] = index;
+    ctx->gpr[5] = subIndex;
+    ctx->gpr[31] = callerR31;
+    ctx->cr = cr;
+}
+PPC_NATIVE_OVERRIDE_VOID(8185DC30, RetroRewind_ActivatePageByIndex_NullGuarded, (CpuContext* ctx), (ctx));

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -1089,13 +1089,13 @@ LONG CALLBACK SehLogger(EXCEPTION_POINTERS* info) {
         info->ExceptionRecord->ExceptionCode == kAsanFatalAppExit) { // ASan reporting - let it print first
         return EXCEPTION_CONTINUE_SEARCH;
     }
-    
+
     // Guard against re-entrancy: if we crash while reporting, don't recurse
     static std::atomic_flag s_inCrashHandler = ATOMIC_FLAG_INIT;
     if (s_inCrashHandler.test_and_set()) {
         std::_Exit(EXIT_FAILURE);
     }
-    
+
     // Report the structured exception with detailed information
     ReportStructuredException(info);
     const auto* record = info->ExceptionRecord;
@@ -1115,7 +1115,7 @@ LONG CALLBACK SehLogger(EXCEPTION_POINTERS* info) {
     DumpHostStackTrace();
 
     WriteFatalLogImpl("seh");
-    
+
     // CRITICAL: Explicitly flush all output to ensure visibility with PowerShell redirection
     std::cerr << '\n';
     RT_LOG(RT_TAG_RUNTIME) << "===== FLUSHING OUTPUT BEFORE EXIT =====" << std::endl;
@@ -1123,7 +1123,7 @@ LONG CALLBACK SehLogger(EXCEPTION_POINTERS* info) {
     std::cout.flush();
     std::fflush(stdout);
     std::fflush(stderr);
-    
+
     std::_Exit(EXIT_FAILURE);
 }
 
@@ -1257,7 +1257,7 @@ int RuntimeMain(int argc, char** argv) {
     // Install exit/terminate handlers to ensure we get crash info
     std::atexit(AtExitHandler);
     std::set_terminate(TerminateHandler);
-    
+
     std::string currentEntryLabel;
 
     try {
@@ -1335,13 +1335,8 @@ int RuntimeMain(int argc, char** argv) {
                 break;
             }
         }
-        // Wine's own D3D12 (vkd3d) is commonly incomplete (e.g. CreateSharedHandle
-        // is unimplemented), where Vulkan just works; Proton's vkd3d-proton is the
-        // exception, but explicitly configuring "d3d12" still opts back into it.
-        // Real Windows is unaffected: "auto" still tries D3D12 first there. This
-        // only steers what aurora tries first - requestedBackend (used below to
-        // decide whether to warn about a fallback) stays BACKEND_AUTO, since the
-        // user asked for "auto", not specifically Vulkan.
+        // Vulkan is preferred under Wine/Proton, but explicitly configuring "d3d12" still opts back into it,
+        // Windows is unaffected: "auto" still tries D3D12 first there
         auroraConfig.desiredBackend =
             (configuredBackend == BACKEND_AUTO && RuntimeHostPlatform::IsRunningUnderWine())
                 ? BACKEND_VULKAN
@@ -1379,10 +1374,10 @@ int RuntimeMain(int argc, char** argv) {
         InitializePersistentCpuContext();
         auto& cpu = GetPersistentCpuContext();
         SeedCpuContext(cpu);
-        
+
         // Initialize the fiber-based threading system
         Fiber::GuestFiberManager::Initialize();
-        
+
         CpuContextScope cpuScope(&cpu);
 
         std::string label = entry->name;
@@ -1397,7 +1392,7 @@ int RuntimeMain(int argc, char** argv) {
         InvokeIndirectCpu(entry->address, &cpu);
         const uint32_t result = cpu.gpr[3];
         RT_LOG(RT_TAG_RUNTIME) << label << " => 0x" << std::hex << result << std::dec << " (" << result << ")" << std::endl;
-        
+
         // Shutdown fiber system
         Fiber::GuestFiberManager::Shutdown();
         WindowPlacementPersistence::Flush(true);

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -163,15 +163,50 @@ void PatchDawnVulkanLoaderForWine() {
         if (importDescriptor->FirstThunk == 0 || !ImportModuleNameMatchesKernel32(moduleName)) {
             continue;
         }
-        // Some linkers omit the Import Name Table (OriginalFirstThunk) and only
-        // emit the IAT; fall back to walking FirstThunk for names in that case
-        // (it still holds unbound name-thunk data until the loader binds it,
-        // and we only read it here before ever writing to it).
-        const DWORD nameThunkRva =
-            importDescriptor->OriginalFirstThunk != 0 ? importDescriptor->OriginalFirstThunk : importDescriptor->FirstThunk;
-        auto* nameThunk = reinterpret_cast<IMAGE_THUNK_DATA64*>(base + nameThunkRva);
         auto* addressThunk = reinterpret_cast<IMAGE_THUNK_DATA64*>(base + importDescriptor->FirstThunk);
         int entryCount = 0;
+
+        if (importDescriptor->OriginalFirstThunk == 0) {
+            // No Import Lookup Table: FirstThunk is the only thunk array, and
+            // by the time GetModuleHandleA above succeeded the loader had
+            // already bound it - its entries are resolved function addresses,
+            // not name-table RVAs, so they must not be walked as
+            // IMAGE_IMPORT_BY_NAME (that would dereference a function address
+            // as if it were an RVA). Identify LoadLibraryExA by its resolved
+            // address instead.
+            const HMODULE kernel32Module = ::GetModuleHandleA("kernel32.dll");
+            const auto realLoadLibraryExA = kernel32Module
+                ? reinterpret_cast<LoadLibraryExA_t>(::GetProcAddress(kernel32Module, "LoadLibraryExA"))
+                : nullptr;
+            if (!realLoadLibraryExA) {
+                RT_LOG(RT_TAG_RUNTIME) << "[runtime] Could not resolve kernel32.dll!LoadLibraryExA; skipping module '"
+                    << moduleName << "' (no Import Lookup Table to walk by name)." << std::endl;
+                continue;
+            }
+            for (; addressThunk->u1.Function != 0; ++addressThunk, ++entryCount) {
+                if (reinterpret_cast<LoadLibraryExA_t>(addressThunk->u1.Function) != realLoadLibraryExA) {
+                    continue;
+                }
+                g_realLoadLibraryExA = realLoadLibraryExA;
+                DWORD oldProtect = 0;
+                if (::VirtualProtect(&addressThunk->u1.Function, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
+                    addressThunk->u1.Function = reinterpret_cast<ULONGLONG>(&HookedLoadLibraryExA);
+                    DWORD ignored = 0;
+                    ::VirtualProtect(&addressThunk->u1.Function, sizeof(void*), oldProtect, &ignored);
+                    RT_LOG(RT_TAG_RUNTIME) << "[runtime] Patched webgpu_dawn.dll's LoadLibraryExA import (module="
+                        << moduleName << ") to work around a Wine LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR bug." << std::endl;
+                } else {
+                    RT_LOG(RT_TAG_RUNTIME) << "[runtime] Found LoadLibraryExA import but VirtualProtect failed, error="
+                        << ::GetLastError() << std::endl;
+                }
+                return;
+            }
+            RT_LOG(RT_TAG_RUNTIME) << "[runtime] Matched import module '" << moduleName << "' (" << entryCount
+                << " entries, no Import Lookup Table) but did not find a bound LoadLibraryExA in it." << std::endl;
+            continue;
+        }
+
+        auto* nameThunk = reinterpret_cast<IMAGE_THUNK_DATA64*>(base + importDescriptor->OriginalFirstThunk);
         for (; nameThunk->u1.AddressOfData != 0; ++nameThunk, ++addressThunk, ++entryCount) {
             if (IMAGE_SNAP_BY_ORDINAL64(nameThunk->u1.Ordinal)) {
                 continue;

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -108,6 +108,97 @@ void ConfigureWindowsFatalDialogBehavior() {
     _CrtSetReportHook(WindowsCrtReportHook);
 }
 
+using LoadLibraryExA_t = HMODULE(WINAPI*)(LPCSTR, HANDLE, DWORD);
+LoadLibraryExA_t g_realLoadLibraryExA = nullptr;
+
+// Wine's LoadLibraryExA rejects LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR with
+// ERROR_INVALID_PARAMETER whenever hFile is null, even though that flag is
+// documented as meaningless (and real Windows silently ignores it) outside of
+// a dependent-DLL load. Dawn's DynamicLib::Open always ORs it into the flags
+// it passes when opening "vulkan-1.dll", which otherwise loads fine under
+// Wine once that one bit is stripped. Patching webgpu_dawn.dll's own IAT
+// entry (rather than Dawn's source, which we don't build) keeps the fix
+// self-contained and a no-op on real Windows.
+HMODULE WINAPI HookedLoadLibraryExA(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags) {
+    if (hFile == nullptr && lpLibFileName != nullptr &&
+        (dwFlags & LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR) != 0 &&
+        _stricmp(lpLibFileName, "vulkan-1.dll") == 0) {
+        dwFlags &= ~static_cast<DWORD>(LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+    }
+    return g_realLoadLibraryExA(lpLibFileName, hFile, dwFlags);
+}
+
+bool ImportModuleNameMatchesKernel32(const char* moduleName) {
+    // Recent toolchains often record kernel32 imports against a virtual API
+    // Set forwarder (e.g. "api-ms-win-core-libraryloader-l1-*.dll") instead of
+    // the literal "kernel32.dll", so match both. The prefix length must be the
+    // literal's strlen (29), not 30: with 30, _strnicmp also compares the
+    // literal's NUL terminator against the real forwarder name's next byte
+    // (e.g. '-' in "...libraryloader-l1-2-0.dll"), which never matches, so the
+    // prefix check silently failed for every real forwarder-named import.
+    constexpr char kLibraryLoaderPrefix[] = "api-ms-win-core-libraryloader";
+    return _stricmp(moduleName, "kernel32.dll") == 0 ||
+           _strnicmp(moduleName, kLibraryLoaderPrefix, sizeof(kLibraryLoaderPrefix) - 1) == 0;
+}
+
+void PatchDawnVulkanLoaderForWine() {
+    const HMODULE dawnModule = ::GetModuleHandleA("webgpu_dawn.dll");
+    if (dawnModule == nullptr) {
+        RT_LOG(RT_TAG_RUNTIME) << "[runtime] webgpu_dawn.dll not loaded; skipping Wine Vulkan loader patch." << std::endl;
+        return;  // Statically-linked Dawn build; nothing to patch.
+    }
+    auto* base = reinterpret_cast<BYTE*>(dawnModule);
+    auto* dosHeader = reinterpret_cast<IMAGE_DOS_HEADER*>(base);
+    auto* ntHeaders = reinterpret_cast<IMAGE_NT_HEADERS64*>(base + dosHeader->e_lfanew);
+    const auto& importDirectory = ntHeaders->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
+    if (importDirectory.VirtualAddress == 0) {
+        RT_LOG(RT_TAG_RUNTIME) << "[runtime] webgpu_dawn.dll has no import directory; skipping Wine Vulkan loader patch." << std::endl;
+        return;
+    }
+
+    auto* importDescriptor = reinterpret_cast<IMAGE_IMPORT_DESCRIPTOR*>(base + importDirectory.VirtualAddress);
+    for (; importDescriptor->Name != 0; ++importDescriptor) {
+        const char* moduleName = reinterpret_cast<const char*>(base + importDescriptor->Name);
+        if (importDescriptor->FirstThunk == 0 || !ImportModuleNameMatchesKernel32(moduleName)) {
+            continue;
+        }
+        // Some linkers omit the Import Name Table (OriginalFirstThunk) and only
+        // emit the IAT; fall back to walking FirstThunk for names in that case
+        // (it still holds unbound name-thunk data until the loader binds it,
+        // and we only read it here before ever writing to it).
+        const DWORD nameThunkRva =
+            importDescriptor->OriginalFirstThunk != 0 ? importDescriptor->OriginalFirstThunk : importDescriptor->FirstThunk;
+        auto* nameThunk = reinterpret_cast<IMAGE_THUNK_DATA64*>(base + nameThunkRva);
+        auto* addressThunk = reinterpret_cast<IMAGE_THUNK_DATA64*>(base + importDescriptor->FirstThunk);
+        int entryCount = 0;
+        for (; nameThunk->u1.AddressOfData != 0; ++nameThunk, ++addressThunk, ++entryCount) {
+            if (IMAGE_SNAP_BY_ORDINAL64(nameThunk->u1.Ordinal)) {
+                continue;
+            }
+            auto* importByName = reinterpret_cast<IMAGE_IMPORT_BY_NAME*>(base + nameThunk->u1.AddressOfData);
+            if (std::strcmp(reinterpret_cast<const char*>(importByName->Name), "LoadLibraryExA") != 0) {
+                continue;
+            }
+            g_realLoadLibraryExA = reinterpret_cast<LoadLibraryExA_t>(addressThunk->u1.Function);
+            DWORD oldProtect = 0;
+            if (::VirtualProtect(&addressThunk->u1.Function, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
+                addressThunk->u1.Function = reinterpret_cast<ULONGLONG>(&HookedLoadLibraryExA);
+                DWORD ignored = 0;
+                ::VirtualProtect(&addressThunk->u1.Function, sizeof(void*), oldProtect, &ignored);
+                RT_LOG(RT_TAG_RUNTIME) << "[runtime] Patched webgpu_dawn.dll's LoadLibraryExA import (module="
+                    << moduleName << ") to work around a Wine LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR bug." << std::endl;
+            } else {
+                RT_LOG(RT_TAG_RUNTIME) << "[runtime] Found LoadLibraryExA import but VirtualProtect failed, error="
+                    << ::GetLastError() << std::endl;
+            }
+            return;
+        }
+        RT_LOG(RT_TAG_RUNTIME) << "[runtime] Matched import module '" << moduleName << "' (" << entryCount
+            << " entries) but did not find LoadLibraryExA in it." << std::endl;
+    }
+    RT_LOG(RT_TAG_RUNTIME) << "[runtime] No kernel32-like import module found in webgpu_dawn.dll; Wine Vulkan loader patch not applied." << std::endl;
+}
+
 class WindowsTimerResolutionGuard {
 public:
     WindowsTimerResolutionGuard() {
@@ -1157,6 +1248,10 @@ int RuntimeMain(int argc, char** argv) {
     WindowsTimerResolutionGuard timerResolutionGuard;
 #endif
     InitializeProcessTranscript(argc, argv);
+#if defined(_WIN32)
+    // Must run after transcript init, or its diagnostics have no console.log to land in yet.
+    PatchDawnVulkanLoaderForWine();
+#endif
     std::signal(SIGABRT, AbortSignalHandler);
     // Install exit/terminate handlers to ensure we get crash info
     std::atexit(AtExitHandler);

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -49,6 +49,7 @@
 #include "aurora_events.h"
 #include "fiber_manager.h"
 #include "hle_stubs.h"
+#include "host_platform.h"
 #include "runtime_config.h"
 #include "runtime_log.h"
 #include "runtime_product.h"
@@ -1327,13 +1328,25 @@ int RuntimeMain(int argc, char** argv) {
         };
 
         const std::string backend = RuntimeConfigFile::GraphicsApi("auto");
+        AuroraBackend configuredBackend = BACKEND_AUTO;
         for (const auto& entry : kGraphicsBackends) {
             if (backend == entry.configName) {
-                auroraConfig.desiredBackend = entry.backend;
+                configuredBackend = entry.backend;
                 break;
             }
         }
-        const AuroraBackend requestedBackend = auroraConfig.desiredBackend;
+        // Wine's own D3D12 (vkd3d) is commonly incomplete (e.g. CreateSharedHandle
+        // is unimplemented), where Vulkan just works; Proton's vkd3d-proton is the
+        // exception, but explicitly configuring "d3d12" still opts back into it.
+        // Real Windows is unaffected: "auto" still tries D3D12 first there. This
+        // only steers what aurora tries first - requestedBackend (used below to
+        // decide whether to warn about a fallback) stays BACKEND_AUTO, since the
+        // user asked for "auto", not specifically Vulkan.
+        auroraConfig.desiredBackend =
+            (configuredBackend == BACKEND_AUTO && RuntimeHostPlatform::IsRunningUnderWine())
+                ? BACKEND_VULKAN
+                : configuredBackend;
+        const AuroraBackend requestedBackend = configuredBackend;
 
         const AuroraInfo auroraInfo = aurora_initialize(0, nullptr, &auroraConfig);
         if (requestedBackend != BACKEND_AUTO && auroraInfo.backend != requestedBackend) {

--- a/runtime/src/settings_overlay.cpp
+++ b/runtime/src/settings_overlay.cpp
@@ -1,6 +1,7 @@
 #include "settings_overlay.h"
 #include "audio_backend.h"
 #include "game_graphics_options.h"
+#include "host_platform.h"
 #include "music_attenuation.h"
 #include "runtime_config.h"
 #include "runtime_log.h"
@@ -531,21 +532,25 @@ void DrawAudioSettings() {
             "Runs the AX/DSP voice mix off the game thread. Turn this off if you "
             "suspect an audio problem; the mix then runs inline as it used to.");
     }
-    ImGui::Separator();
-    if (ImGui::Checkbox("Mute game music while external media is playing",
-                        &g_attenuateMusicWhenMediaPlays)) {
-        MusicAttenuation::SetEnabled(g_attenuateMusicWhenMediaPlays);
-        RuntimeConfigFile::SetAttenuateMusicWhenMediaPlays(g_attenuateMusicWhenMediaPlays);
-    }
-    if (g_attenuateMusicWhenMediaPlays) {
-        if (MusicAttenuation::IsExternalMediaPlaying()) {
-            ImGui::TextDisabled("External media is playing; game music is muted.");
-        } else if (!MusicAttenuation::IsMediaControlInitializationComplete()) {
-            ImGui::TextDisabled("Waiting for Windows Media Control...");
-        } else if (!MusicAttenuation::IsMediaControlAvailable()) {
-            ImGui::TextDisabled("Windows Media Control is unavailable.");
-        } else {
-            ImGui::TextDisabled("No external media is currently playing.");
+    // Windows Media Control (winrt/Windows.Media.Control.h) wont do anything
+    // under Wine/Proton, so hide the toggle
+    if (!RuntimeHostPlatform::IsRunningUnderWine()) {
+        ImGui::Separator();
+        if (ImGui::Checkbox("Mute game music while external media is playing",
+                            &g_attenuateMusicWhenMediaPlays)) {
+            MusicAttenuation::SetEnabled(g_attenuateMusicWhenMediaPlays);
+            RuntimeConfigFile::SetAttenuateMusicWhenMediaPlays(g_attenuateMusicWhenMediaPlays);
+        }
+        if (g_attenuateMusicWhenMediaPlays) {
+            if (MusicAttenuation::IsExternalMediaPlaying()) {
+                ImGui::TextDisabled("External media is playing; game music is muted.");
+            } else if (!MusicAttenuation::IsMediaControlInitializationComplete()) {
+                ImGui::TextDisabled("Waiting for Windows Media Control...");
+            } else if (!MusicAttenuation::IsMediaControlAvailable()) {
+                ImGui::TextDisabled("Windows Media Control is unavailable.");
+            } else {
+                ImGui::TextDisabled("No external media is currently playing.");
+            }
         }
     }
 }
@@ -579,7 +584,11 @@ void DrawGraphicsSettings() {
         "Borderless fullscreen",
         "Exclusive fullscreen",
     };
-    if (ImGui::Combo("Display mode", &g_displayMode, kDisplayModes, static_cast<int>(std::size(kDisplayModes)))) {
+    // Exclusive fullscreen doesn't work that well under Wine/Proton
+    const int displayModeCount = RuntimeHostPlatform::IsRunningUnderWine()
+        ? static_cast<int>(std::size(kDisplayModes)) - 1
+        : static_cast<int>(std::size(kDisplayModes));
+    if (ImGui::Combo("Display mode", &g_displayMode, kDisplayModes, displayModeCount)) {
         const auto mode = static_cast<AuroraDisplayMode>(g_displayMode);
         aurora_set_display_mode(mode);
         const AuroraDisplayMode activeMode = aurora_get_display_mode();
@@ -639,6 +648,9 @@ void DrawGraphicsSettings() {
     }
     ImGui::Separator();
     ImGui::Text("Graphics API: %s", GraphicsApiDisplayName());
+    if (RuntimeHostPlatform::IsRunningUnderWine()) {
+        ImGui::Text("Running under Wine/Proton");
+    }
 }
 
 void DrawFpsOverlay() {
@@ -847,7 +859,7 @@ void InitializeRuntimeSettings() noexcept {
     MusicAttenuation::SetSoundEffectsVolume(static_cast<float>(g_soundEffectsVolumePercent) / 100.0f);
     MusicAttenuation::SetUiVolume(static_cast<float>(g_uiVolumePercent) / 100.0f);
     MusicAttenuation::SetVoicesVolume(static_cast<float>(g_voicesVolumePercent) / 100.0f);
-    MusicAttenuation::SetEnabled(g_attenuateMusicWhenMediaPlays);
+    MusicAttenuation::SetEnabled(g_attenuateMusicWhenMediaPlays && !RuntimeHostPlatform::IsRunningUnderWine());
     RuntimeGameGraphicsOptions::SetDisabledPostProcessingPaths(g_disabledPostProcessingPaths);
     const uint32_t targetFps = kFrameInterpolationTargetFps[static_cast<size_t>(g_frameInterpolationMode)];
     LimitResolutionForFrameRate();


### PR DESCRIPTION
Wiicompiled can be built on Windows, but can be ran on Linux under Wine/Proton*.

This PR addresses some oddities when this happens, including:
- Detection of Proton/Wine through `host_platform.h`, specifically `IsRunningUnderWine()`
- Setting Vulkan as the default on Linux, since it has way better performance than DirectX12 (I couldn't achieve 180FPS with DX12), either API can still be forced
- Patches `webgpu_dawn.dll`, as it fails to load Vulkan under Proton (they are heavily dependant on specific windows APIs)
- Exclusive fullscreen not being an accessible option (borderless fullscreen only) due being buggy/redundant on Linux
-  The Windows Media Control-based "mute while external media plays" feature is hidden and disabled (this feature could be re-added with `mpris` in the future)
- The settings overlay shows "Running under Wine/Proton" when detected (convenience)

Known issues: using ALT+ENTER to exit out of fullscreen could show black borders around the window, until manually exiting fullscreen (depending on the DE)

Video of the project running successfully on Linux (CachyOS x86_64, Linux 7.2.0-1-cachyos, mesa version: 26.2.1-1):
https://github.com/user-attachments/assets/dc9ae22f-b4e0-4c57-a2ad-f15ad4f3047b

※ I'll submit another PR regarding building on Linux, I wanted to split the two for now.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a controller-mapping setup wizard with saved mappings and guided configuration.
  - Improved compatibility when running on Wine or Proton.
  - Automatically favors Vulkan graphics on Wine/Proton when no backend is selected.
  - Added clear Wine/Proton status information in graphics settings.

- **Bug Fixes**
  - Prevented unsupported exclusive fullscreen and external-media music attenuation options from appearing under Wine/Proton.
  - Adjusted display mode handling to use borderless mode where necessary.
  - Improved stability when handling missing pages and null virtual calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->