### PR TITLE
Fix paranthesees

### DIFF
--- a/Launcher/LocalBuild.ps1
+++ b/Launcher/LocalBuild.ps1
@@ -151,9 +151,10 @@ if ($Profile -ne 'both' -and -not [string]::IsNullOrWhiteSpace($BaseOutputDirect
     throw '-BaseOutputDirectory is valid only with -Profile both.'
 }
 $translator = Join-Path $Toolkit 'Translator\Translator.Cli.exe'
-$cmake = Join-Path $Toolkit 'CMake\bin\cmake.exe'
-$ninja = Join-Path $Toolkit 'Ninja\ninja.exe'
-$toolchainBin = Join-Path $Toolkit 'llvm-mingw\bin'
+$toolchain = Get-MkwShellSafeToolchainRoot $Toolkit
+$cmake = Join-Path $toolchain 'CMake\bin\cmake.exe'
+$ninja = Join-Path $toolchain 'Ninja\ninja.exe'
+$toolchainBin = Join-Path $toolchain 'llvm-mingw\bin'
 $cc = Join-Path $toolchainBin 'x86_64-w64-mingw32-clang.exe'
 $cxx = Join-Path $toolchainBin 'x86_64-w64-mingw32-clang++.exe'
 $windres = Join-Path $toolchainBin 'x86_64-w64-mingw32-windres.exe'
@@ -203,7 +204,7 @@ if ($Parallel -gt 0) {
 $oldPath = $env:PATH
 $oldDotnet = $env:DOTNET_ROOT
 try {
-    $env:PATH = Get-MkwToolchainPath $Toolkit
+    $env:PATH = Get-MkwToolchainPath $toolchain
     Remove-Item Env:DOTNET_ROOT -ErrorAction SilentlyContinue
     Push-Location $Workspace
     try {

--- a/Launcher/NativeBuildFlags.ps1
+++ b/Launcher/NativeBuildFlags.ps1
@@ -40,6 +40,41 @@ function Get-MkwToolchainPath([string]$ToolchainRoot) {
     ) -join ';')
 }
 
+function Get-MkwShellSafeToolchainRoot([string]$ToolchainRoot) {
+    if ([string]::IsNullOrWhiteSpace($ToolchainRoot)) { throw 'A toolchain root is required.' }
+    $full = [IO.Path]::GetFullPath($ToolchainRoot).TrimEnd('\')
+    if ($full -notmatch '[()&^%!]') { return $full }
+
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = $sha.ComputeHash([Text.Encoding]::UTF8.GetBytes($full.ToLowerInvariant()))
+    } finally { $sha.Dispose() }
+    $linkName = 'toolchain-' + ((($bytes[0..7]) | ForEach-Object { $_.ToString('x2') }) -join '')
+
+    $failures = @()
+    foreach ($base in @($env:ProgramData, $env:PUBLIC)) {
+        if ([string]::IsNullOrWhiteSpace($base) -or $base -match '[()&^%! ]') { continue }
+        $link = Join-Path (Join-Path $base 'WiiCompiled') $linkName
+        try {
+            [IO.Directory]::CreateDirectory((Split-Path -Parent $link)) | Out-Null
+            # The name already identifies the target, so an existing junction that still resolves is
+            # this one; only a broken leftover is replaced. Directory.Delete removes the reparse
+            # point itself, where Remove-Item -Recurse would delete the toolchain it points at.
+            if (-not (Test-Path -LiteralPath (Join-Path $link 'CMake\bin\cmake.exe') -PathType Leaf)) {
+                if (Test-Path -LiteralPath $link) { [IO.Directory]::Delete($link) }
+                New-Item -ItemType Junction -Path $link -Target $full -ErrorAction Stop | Out-Null
+            }
+            Write-Host "MKWCBUILD: Building through $link, because $full contains characters cmd.exe cannot parse"
+            return $link
+        } catch {
+            $failures += "$link ($($_.Exception.Message))"
+        }
+    }
+    throw ("The toolchain path $full contains a character (one of ( ) & ^ % !) that the compiler " +
+        'cannot be invoked through, and no junction to it could be created: ' + ($failures -join '; ') +
+        '. Install to a path without those characters.')
+}
+
 function Get-MkwProjectPins([string]$ProjectFile) {
     <#
     The Mario Kart Wii facts pinned by projects/mkwii/recomp.yml (game identity, clean input

--- a/Launcher/NativeBuildFlags.ps1
+++ b/Launcher/NativeBuildFlags.ps1
@@ -42,7 +42,9 @@ function Get-MkwToolchainPath([string]$ToolchainRoot) {
 
 function Get-MkwShellSafeToolchainRoot([string]$ToolchainRoot) {
     if ([string]::IsNullOrWhiteSpace($ToolchainRoot)) { throw 'A toolchain root is required.' }
-    $full = [IO.Path]::GetFullPath($ToolchainRoot).TrimEnd('\')
+    $full = [IO.Path]::GetFullPath($ToolchainRoot)
+    # A drive root keeps its separator: "C:" is relative to the current directory on that drive.
+    if ($full -ne [IO.Path]::GetPathRoot($full)) { $full = $full.TrimEnd('\') }
     if ($full -notmatch '[()&^%!]') { return $full }
 
     $sha = [Security.Cryptography.SHA256]::Create()


### PR DESCRIPTION
Fix for https://github.com/patchzyy/Wiicompiled/issues/75

( is treated as command grouping, so folder was not parsed correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build setup for toolchain paths containing characters that are difficult for Windows shell commands to process.
  * Added automatic handling for unsafe paths by creating or reusing a compatible redirected path.
  * Preserved correct handling of drive-root paths while normalizing other toolchain paths.
  * Ensured CMake, Ninja, LLVM, and environment setup consistently use the resolved toolchain location.
  * Added clearer error reporting when a compatible path cannot be created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->