### PR TITLE
Add input macros, LB/RB bumper support and controller vibration toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Press **F10** while the game window has focus:
 - Internal resolution
 - FPS counter
 - Controller assignment for all four ports
-- Full per-controller button mapping
+- Full per-controller button mapping, including the bumpers
+- Frame-synced input macros
+- Controller vibration on/off
 - Volume, instant mute, and the music ducking toggle
 
 Everything you change is saved to `Config.toml` on the spot and restored next launch.
@@ -57,6 +59,17 @@ The port does NOT pretend to be a Wii Remote or Classic Controller.
 Mappings are positional (`south`, `east`, `west`, `north`) rather than Xbox-labelled, so the
 same config makes sense on Xbox, PlayStation, Nintendo and generic SDL pads alike, and extra
 inputs like paddles, touchpads and share buttons show up when the hardware reports them.
+
+**Input macros.** 
+Hold one button to repeat a GameCube input on a frame pattern, for example holding LB to spam
+D-pad Up. The pattern is counted in the game's own input polls rather than in milliseconds, so it
+does not change when frame interpolation is on. The game only registers a new press after a
+release, so one frame held / one frame released is the fastest repeat that does anything: 30
+presses per second, not 60.
+
+**Vibration toggle.** 
+Force feedback can be turned off for every port at once, including controllers on a GameCube
+adapter.
 
 ## Requirements
 

--- a/runtime/include/controller_button_names.h
+++ b/runtime/include/controller_button_names.h
@@ -1,0 +1,159 @@
+#pragma once
+
+// The single vocabulary shared by everything that has to turn a Config.toml
+// controller name into a real button: the F10 settings bar, the macro engine,
+// and the startup mapping pass. Keeping one table here means a name that the
+// settings bar offers is always a name the config parser accepts, and vice
+// versa; the two used to drift because each side carried its own copy.
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include <SDL3/SDL_gamepad.h>
+#include <dolphin/pad.h>
+
+namespace ControllerNames {
+
+// A GameCube button as the game sees it, with the Config.toml key that selects
+// it. Order matches RuntimeConfigFile::kControllerButtonKeys.
+struct GameCubeButtonItem {
+    const char* configKey;
+    const char* label;
+    PADButton padButton;
+};
+
+inline constexpr std::array<GameCubeButtonItem, PAD_BUTTON_COUNT> kGameCubeButtons = {{
+    {"a", "A", PAD_BUTTON_A},
+    {"b", "B", PAD_BUTTON_B},
+    {"x", "X", PAD_BUTTON_X},
+    {"y", "Y", PAD_BUTTON_Y},
+    {"start", "Start", PAD_BUTTON_START},
+    {"z", "Z", PAD_TRIGGER_Z},
+    {"l", "L", PAD_TRIGGER_L},
+    {"r", "R", PAD_TRIGGER_R},
+    {"up", "D-pad Up", PAD_BUTTON_UP},
+    {"down", "D-pad Down", PAD_BUTTON_DOWN},
+    {"left", "D-pad Left", PAD_BUTTON_LEFT},
+    {"right", "D-pad Right", PAD_BUTTON_RIGHT},
+}};
+
+// A physical button on the host pad. Names are positional (south/east/...)
+// rather than Xbox-labelled so one config reads the same on any hardware.
+struct NativeButtonItem {
+    const char* configName;
+    const char* label;
+    uint32_t nativeButton;
+};
+
+inline constexpr std::array<NativeButtonItem, SDL_GAMEPAD_BUTTON_COUNT + 1> kNativeButtons = {{
+    {"unmapped", "Unmapped / analog trigger", PAD_NATIVE_BUTTON_INVALID},
+    {"south", "South (A / Cross)", SDL_GAMEPAD_BUTTON_SOUTH},
+    {"east", "East (B / Circle)", SDL_GAMEPAD_BUTTON_EAST},
+    {"west", "West (X / Square)", SDL_GAMEPAD_BUTTON_WEST},
+    {"north", "North (Y / Triangle)", SDL_GAMEPAD_BUTTON_NORTH},
+    {"back", "Back / Select / Create", SDL_GAMEPAD_BUTTON_BACK},
+    {"guide", "Guide / Home / PS", SDL_GAMEPAD_BUTTON_GUIDE},
+    {"start", "Start / Options", SDL_GAMEPAD_BUTTON_START},
+    {"left_stick", "Left stick click (L3)", SDL_GAMEPAD_BUTTON_LEFT_STICK},
+    {"right_stick", "Right stick click (R3)", SDL_GAMEPAD_BUTTON_RIGHT_STICK},
+    {"left_shoulder", "Left bumper (LB / L1)", SDL_GAMEPAD_BUTTON_LEFT_SHOULDER},
+    {"right_shoulder", "Right bumper (RB / R1)", SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER},
+    {"dpad_up", "D-pad Up", SDL_GAMEPAD_BUTTON_DPAD_UP},
+    {"dpad_down", "D-pad Down", SDL_GAMEPAD_BUTTON_DPAD_DOWN},
+    {"dpad_left", "D-pad Left", SDL_GAMEPAD_BUTTON_DPAD_LEFT},
+    {"dpad_right", "D-pad Right", SDL_GAMEPAD_BUTTON_DPAD_RIGHT},
+    {"misc1", "Misc 1 / Share / Mic", SDL_GAMEPAD_BUTTON_MISC1},
+    {"right_paddle1", "Right paddle 1", SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1},
+    {"left_paddle1", "Left paddle 1", SDL_GAMEPAD_BUTTON_LEFT_PADDLE1},
+    {"right_paddle2", "Right paddle 2", SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2},
+    {"left_paddle2", "Left paddle 2", SDL_GAMEPAD_BUTTON_LEFT_PADDLE2},
+    {"touchpad", "Touchpad click", SDL_GAMEPAD_BUTTON_TOUCHPAD},
+    {"misc2", "Misc 2", SDL_GAMEPAD_BUTTON_MISC2},
+    {"misc3", "Misc 3 / GC L click", SDL_GAMEPAD_BUTTON_MISC3},
+    {"misc4", "Misc 4 / GC R click", SDL_GAMEPAD_BUTTON_MISC4},
+    {"misc5", "Misc 5", SDL_GAMEPAD_BUTTON_MISC5},
+    {"misc6", "Misc 6", SDL_GAMEPAD_BUTTON_MISC6},
+}};
+
+inline std::string TrimToken(std::string_view token) {
+    const size_t begin = token.find_first_not_of(" \t");
+    if (begin == std::string_view::npos) {
+        return {};
+    }
+    const size_t end = token.find_last_not_of(" \t");
+    return std::string(token.substr(begin, end - begin + 1));
+}
+
+inline const NativeButtonItem* FindNativeButton(std::string_view configName) {
+    const std::string name = TrimToken(configName);
+    const auto it = std::find_if(kNativeButtons.begin(), kNativeButtons.end(),
+                                 [&](const NativeButtonItem& item) { return name == item.configName; });
+    return it == kNativeButtons.end() ? nullptr : &*it;
+}
+
+// Falls back to the "unmapped" entry so callers always have a label to draw.
+inline const NativeButtonItem& NativeButtonForValue(uint32_t nativeButton) {
+    const auto it = std::find_if(kNativeButtons.begin(), kNativeButtons.end(),
+                                 [&](const NativeButtonItem& item) { return nativeButton == item.nativeButton; });
+    return it == kNativeButtons.end() ? kNativeButtons.front() : *it;
+}
+
+inline const GameCubeButtonItem* FindGameCubeButton(std::string_view configKey) {
+    const std::string key = TrimToken(configKey);
+    const auto it = std::find_if(kGameCubeButtons.begin(), kGameCubeButtons.end(),
+                                 [&](const GameCubeButtonItem& item) { return key == item.configKey; });
+    return it == kGameCubeButtons.end() ? nullptr : &*it;
+}
+
+// "up" or "up,a" -> the OR of those GC button bits. Unknown names are skipped so
+// a typo costs one button instead of the whole macro.
+inline uint16_t GameCubeMaskFromKeys(std::string_view keys) {
+    uint16_t mask = 0;
+    size_t begin = 0;
+    while (begin <= keys.size()) {
+        const size_t comma = keys.find(',', begin);
+        const std::string_view token =
+            keys.substr(begin, comma == std::string_view::npos ? std::string_view::npos : comma - begin);
+        if (const GameCubeButtonItem* item = FindGameCubeButton(token)) {
+            mask |= static_cast<uint16_t>(item->padButton);
+        }
+        if (comma == std::string_view::npos) {
+            break;
+        }
+        begin = comma + 1;
+    }
+    return mask;
+}
+
+inline std::string GameCubeKeysFromMask(uint16_t mask) {
+    std::string keys;
+    for (const auto& item : kGameCubeButtons) {
+        if ((mask & static_cast<uint16_t>(item.padButton)) == 0) {
+            continue;
+        }
+        if (!keys.empty()) {
+            keys += ',';
+        }
+        keys += item.configKey;
+    }
+    return keys;
+}
+
+inline std::string GameCubeLabelsFromMask(uint16_t mask) {
+    std::string labels;
+    for (const auto& item : kGameCubeButtons) {
+        if ((mask & static_cast<uint16_t>(item.padButton)) == 0) {
+            continue;
+        }
+        if (!labels.empty()) {
+            labels += " + ";
+        }
+        labels += item.label;
+    }
+    return labels.empty() ? std::string("None") : labels;
+}
+
+} // namespace ControllerNames

--- a/runtime/include/input_macros.h
+++ b/runtime/include/input_macros.h
@@ -1,0 +1,75 @@
+#pragma once
+
+// Frame-synced input macros.
+//
+// A macro watches one physical button on a host pad and, while it is held,
+// stamps a set of GameCube buttons into the status the game is about to read,
+// alternating pressed and released on a frame pattern. Holding LB to send D-pad
+// Up as fast as the game can register it is the motivating case.
+//
+// The pattern is counted in guest input polls, which the game performs once per
+// game frame. That is deliberately not wall-clock time and not presented frames,
+// so the pattern behaves identically with frame interpolation on or off, and
+// every press the pattern emits is separated by a release the game can see.
+//
+// Why a press cannot land on *every* frame: the game recognises a new press by
+// seeing the button go from released to pressed. A button reported as held on
+// consecutive frames is one long press, not many. The tightest real spam is
+// therefore one frame pressed, one frame released, which is what hold=1,
+// release=1 produces: 30 distinct presses per second at 60 fps.
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include <dolphin/pad.h>
+
+namespace InputMacros {
+
+inline constexpr size_t kSlotCount = 4;
+
+// Lowest and highest frame counts a slot may use for either half of its pattern.
+inline constexpr uint32_t kMinFrames = 1;
+inline constexpr uint32_t kMaxFrames = 60;
+
+struct Slot {
+    bool enabled = false;
+    uint32_t port = 0;                                // zero-based game port
+    uint32_t trigger = PAD_NATIVE_BUTTON_INVALID;     // physical SDL button
+    uint16_t output = 0;                              // OR of PAD_* button bits
+    uint32_t holdFrames = 1;
+    uint32_t releaseFrames = 1;
+
+    bool IsRunnable() const {
+        return enabled && output != 0 && trigger != PAD_NATIVE_BUTTON_INVALID && port < PAD_CHANMAX;
+    }
+};
+
+// Rebuild the engine's view of the [controller] macro_N_* keys in Config.toml.
+// Safe to call at any time; running patterns are reset.
+void Reload() noexcept;
+
+// Read one slot. Returns a disabled slot for an out-of-range index.
+Slot GetSlot(size_t index) noexcept;
+
+// Replace one slot in the running engine without touching Config.toml. Use this
+// for controls that change continuously, such as a slider being dragged; each
+// persist rewrites the whole file, which is far too much for a per-frame edit.
+void ApplySlot(size_t index, const Slot& slot) noexcept;
+
+// Write the slot the engine is currently running to Config.toml.
+void PersistSlot(size_t index) noexcept;
+
+// Replace one slot and persist it. The right call for discrete edits.
+void SetSlot(size_t index, const Slot& slot) noexcept;
+
+// Mix macro output into a freshly read status set. Call exactly once per guest
+// PADRead, after every other input source has been merged in, so a macro can add
+// to what the player is physically holding rather than being overwritten by it.
+void Apply(std::array<PADStatus, PAD_CHANMAX>& statuses) noexcept;
+
+// True while the slot is emitting a press. Drives the activity dot in the F10
+// bar so a misconfigured macro is obvious without leaving the menu.
+bool SlotIsFiring(size_t index) noexcept;
+
+} // namespace InputMacros

--- a/runtime/include/runtime_config.h
+++ b/runtime/include/runtime_config.h
@@ -25,6 +25,22 @@
 #include <shlobj.h>
 #endif
 
+// How many macro slots Config.toml carries. Kept in step with
+// InputMacros::kSlotCount, which is the value the input path uses.
+inline constexpr size_t kMacroSlotCount = 4;
+
+// One [controller] macro_N_* group, stored as written rather than resolved: the
+// button names stay strings here so this header does not need SDL, and
+// input_macros.cpp turns them into real buttons when it loads them.
+struct MacroSetting {
+    bool enabled = false;
+    uint32_t port = 0;        // zero-based game port
+    std::string trigger;      // physical button name, e.g. "left_shoulder"
+    std::string output;       // GameCube button keys, e.g. "up" or "up,a"
+    uint32_t holdFrames = 1;  // frames the output is held per cycle
+    uint32_t releaseFrames = 1;
+};
+
 struct RuntimeUserConfig {
     std::optional<bool> widescreen;
     std::optional<int32_t> windowPosX;
@@ -63,6 +79,11 @@ struct RuntimeUserConfig {
     // One-based physical WUP-028 adapter port assigned to each game port.
     // Zero or a missing value means the adapter does not own that game port.
     std::array<uint32_t, 4> gameCubeAdapterPorts{};
+    // Force feedback for every port at once. The game still drives the motors
+    // normally; this decides whether those requests reach the hardware.
+    std::optional<bool> rumbleEnabled;
+    // Frame-synced macro slots; see MacroSetting above and input_macros.h.
+    std::array<MacroSetting, kMacroSlotCount> macros{};
 };
 
 namespace RuntimeConfigFile {
@@ -248,6 +269,25 @@ inline void EnsureConfigFile() {
               "# guest can observe it. Set to false to mix inline on the guest\n"
               "# thread exactly as the runtime did before.\n"
               "mix_worker = true\n\n"
+              "[controller]\n"
+              "# Force feedback for every port. The game still asks for rumble;\n"
+              "# this decides whether those requests reach the hardware.\n"
+              "rumble = true\n"
+              "# Frame-synced macros. While the trigger button is held, the\n"
+              "# output buttons are pressed for hold_frames game frames, then\n"
+              "# released for release_frames, repeating. The game only registers\n"
+              "# a new press after a release, so 1/1 is the fastest useful\n"
+              "# repeat: 30 presses per second at 60 fps.\n"
+              "# Trigger names are physical buttons (left_shoulder, touchpad,\n"
+              "# right_paddle1, ...); output names are GameCube buttons\n"
+              "# (a, b, x, y, start, z, l, r, up, down, left, right) and may be\n"
+              "# comma-separated to press several at once.\n"
+              "# macro_1_enabled = true\n"
+              "# macro_1_port = 1\n"
+              "# macro_1_trigger = \"left_shoulder\"\n"
+              "# macro_1_output = \"up\"\n"
+              "# macro_1_hold_frames = 1\n"
+              "# macro_1_release_frames = 1\n\n"
               "[network]\n"
               "enabled = true\n\n"
               "[paths]\n"
@@ -330,6 +370,27 @@ inline RuntimeUserConfig ParseConfigDocument(const toml::value& document) {
         const std::string key = "adapter_port_" + std::to_string(index + 1);
         if (auto value = FindConfigUint(document, "controller", key); value && *value <= 4) {
             config.gameCubeAdapterPorts[index] = *value;
+        }
+    }
+
+    config.rumbleEnabled = FindConfigValue<bool>(document, "controller", "rumble");
+
+    for (size_t index = 0; index < config.macros.size(); ++index) {
+        const std::string prefix = "macro_" + std::to_string(index + 1) + "_";
+        MacroSetting& macro = config.macros[index];
+        macro.enabled = FindConfigValue<bool>(document, "controller", prefix + "enabled").value_or(false);
+        if (auto value = FindConfigUint(document, "controller", prefix + "port"); value && *value >= 1 && *value <= 4) {
+            macro.port = *value - 1;
+        }
+        macro.trigger =
+            FindConfigValue<std::string>(document, "controller", prefix + "trigger").value_or(std::string());
+        macro.output =
+            FindConfigValue<std::string>(document, "controller", prefix + "output").value_or(std::string());
+        if (auto value = FindConfigUint(document, "controller", prefix + "hold_frames"); value && *value != 0) {
+            macro.holdFrames = *value;
+        }
+        if (auto value = FindConfigUint(document, "controller", prefix + "release_frames"); value && *value != 0) {
+            macro.releaseFrames = *value;
         }
     }
 
@@ -606,6 +667,38 @@ inline bool SetGameCubeAdapterPort(size_t gamePort, int physicalPort) {
     const uint32_t storedPort = physicalPort < 0 ? 0u : static_cast<uint32_t>(physicalPort + 1);
     Mutable().gameCubeAdapterPorts[gamePort] = storedPort;
     return WriteSetting("controller", "adapter_port_" + std::to_string(gamePort + 1), std::to_string(storedPort));
+}
+
+inline bool RumbleEnabled(bool fallback = true) {
+    return Get().rumbleEnabled.value_or(fallback);
+}
+
+inline bool SetRumbleEnabled(bool value) {
+    Mutable().rumbleEnabled = value;
+    return WriteSetting("controller", "rumble", value ? "true" : "false");
+}
+
+inline const MacroSetting& Macro(size_t index) {
+    static const MacroSetting empty;
+    return index < Get().macros.size() ? Get().macros[index] : empty;
+}
+
+// Writes the whole slot in one pass. The keys are flat rather than an array of
+// tables because WriteSetting only understands "[section] key = value", and that
+// keeps hand-edited files and overlay-edited files identical.
+inline bool SetMacro(size_t index, const MacroSetting& macro) {
+    if (index >= Mutable().macros.size()) {
+        return false;
+    }
+    Mutable().macros[index] = macro;
+    const std::string prefix = "macro_" + std::to_string(index + 1) + "_";
+    bool ok = WriteSetting("controller", prefix + "enabled", macro.enabled ? "true" : "false");
+    ok = WriteSetting("controller", prefix + "port", std::to_string(macro.port + 1)) && ok;
+    ok = WriteSetting("controller", prefix + "trigger", FormatString(macro.trigger)) && ok;
+    ok = WriteSetting("controller", prefix + "output", FormatString(macro.output)) && ok;
+    ok = WriteSetting("controller", prefix + "hold_frames", std::to_string(macro.holdFrames)) && ok;
+    ok = WriteSetting("controller", prefix + "release_frames", std::to_string(macro.releaseFrames)) && ok;
+    return ok;
 }
 
 inline bool SetAudioVolume(float value) {

--- a/runtime/src/hle/input/pad.cpp
+++ b/runtime/src/hle/input/pad.cpp
@@ -1,17 +1,80 @@
 #include "hle_stubs.h"
 #include "memory.h"
 #include "hle/controller_status_contract.h"
+#include "input_macros.h"
 #include "wup028_adapter.h"
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 
+#include <SDL3/SDL_gamepad.h>
 #include <dolphin/pad.h>
 
 namespace {
+
+// Read on the guest thread every time the game asks for rumble, written from
+// the overlay thread when the setting changes, so it cannot live in the config
+// struct like settings that are only ever read at startup.
+std::atomic<bool> g_rumbleEnabled{true};
+
+bool NativeButtonHeld(SDL_Gamepad* gamepad, uint32_t nativeButton) {
+    if (gamepad == nullptr || nativeButton == PAD_NATIVE_BUTTON_INVALID ||
+        nativeButton >= SDL_GAMEPAD_BUTTON_COUNT) {
+        return false;
+    }
+    return SDL_GetGamepadButton(gamepad, static_cast<SDL_GamepadButton>(nativeButton));
+}
+
+// A digital button bound to L or R (a bumper, or a GameCube trigger's click
+// switch) sets the button bit but leaves the analog value at rest, because the
+// button has no travel of its own. On real hardware the click only engages at
+// full depression, so report the trigger as fully pulled; otherwise code that
+// reads the analog value sees a press worth nothing.
+void FillTriggersHeldByButtons(std::array<PADStatus, PAD_CHANMAX>& statuses) {
+    for (uint32_t port = 0; port < PAD_CHANMAX; ++port) {
+        if (statuses[port].err != PAD_ERR_NONE) {
+            continue;
+        }
+        const s32 index = PADGetIndexForPort(port);
+        if (index < 0) {
+            continue;
+        }
+        SDL_Gamepad* gamepad = PADGetSDLGamepadForIndex(static_cast<u32>(index));
+        if (gamepad == nullptr) {
+            continue;
+        }
+
+        const auto scan = [&](PADButtonMapping* mappings, u32 count) {
+            if (mappings == nullptr) {
+                return;
+            }
+            for (u32 i = 0; i < count; ++i) {
+                const PADButtonMapping& mapping = mappings[i];
+                if (mapping.padButton != PAD_TRIGGER_L && mapping.padButton != PAD_TRIGGER_R) {
+                    continue;
+                }
+                if (!NativeButtonHeld(gamepad, mapping.nativeButton)) {
+                    continue;
+                }
+                if (mapping.padButton == PAD_TRIGGER_L) {
+                    statuses[port].triggerLeft = 255;
+                } else {
+                    statuses[port].triggerRight = 255;
+                }
+            }
+        };
+
+        u32 count = 0;
+        scan(PADGetButtonMappings(port, &count), count);
+        count = 0;
+        scan(PADGetAltButtonMappings(port, &count), count);
+    }
+}
 
 void WritePadStatus(uint32_t base, const PADStatus& status) {
     const auto guestStatus = PadStatusContract::Encode({
@@ -32,6 +95,13 @@ void WritePadStatus(uint32_t base, const PADStatus& status) {
 
 } // namespace
 
+// Called by the F10 settings bar. Declared where it is used rather than in a
+// header, since this is the only caller.
+extern "C" void PAD_HLE_SetRumbleEnabled(bool enabled)
+{
+    g_rumbleEnabled.store(enabled, std::memory_order_relaxed);
+}
+
 extern "C" uint32_t PAD__Init_HLE()
 {
     Wup028Adapter::Initialize();
@@ -45,9 +115,9 @@ extern "C" uint32_t PAD__Read_HLE(uint32_t statusPtr)
         return 0;
     }
 
-    PADStatus statuses[PAD_CHANMAX]{};
+    std::array<PADStatus, PAD_CHANMAX> statuses{};
     std::array<PADStatus, PAD_CHANMAX> adapterStatuses{};
-    uint32_t rumbleMask = PADRead(statuses);
+    uint32_t rumbleMask = PADRead(statuses.data());
     if (Wup028Adapter::Read(adapterStatuses) && !PADIsInputBlocked()) {
         for (uint32_t port = 0; port < PAD_CHANMAX; ++port) {
             if (adapterStatuses[port].err == PAD_ERR_NONE) {
@@ -56,6 +126,13 @@ extern "C" uint32_t PAD__Read_HLE(uint32_t statusPtr)
             }
         }
     }
+
+    FillTriggersHeldByButtons(statuses);
+
+    // Last, so a macro adds to whatever the player is physically holding rather
+    // than being overwritten by a later input source. This is also the game's
+    // own once-per-frame input poll, which is the cadence macro patterns use.
+    InputMacros::Apply(statuses);
 
     try {
         for (uint32_t i = 0; i < PAD_CHANMAX; ++i) {
@@ -84,6 +161,12 @@ PPC_NATIVE_OVERRIDE(801AF1E4, PAD__Recalibrate_HLE, uint32_t, (uint32_t mask), (
 
 extern "C" void PAD__ControlMotor_HLE(int32_t chan, uint32_t command)
 {
+    // Downgrade to a stop rather than dropping the call: the game tracks motor
+    // state and expects its transitions honoured, and a stop also kills
+    // anything still running from before the setting was turned off.
+    if (command == PAD_MOTOR_RUMBLE && !g_rumbleEnabled.load(std::memory_order_relaxed)) {
+        command = PAD_MOTOR_STOP;
+    }
     if (!Wup028Adapter::SetRumble(static_cast<uint32_t>(chan), command == PAD_MOTOR_RUMBLE)) {
         PADControlMotor(chan, command);
     }

--- a/runtime/src/input_macros.cpp
+++ b/runtime/src/input_macros.cpp
@@ -1,0 +1,213 @@
+#include "input_macros.h"
+
+#include "controller_button_names.h"
+#include "runtime_config.h"
+#include "runtime_log.h"
+
+#include <algorithm>
+#include <mutex>
+#include <string>
+
+#include <SDL3/SDL_gamepad.h>
+
+namespace InputMacros {
+namespace {
+
+// Per-slot pattern state. Lives beside the configuration but is never persisted.
+struct RunState {
+    bool firing = false;      // emitting a press this frame
+    bool triggerHeld = false; // trigger state as of the last Apply
+    uint32_t framesInPhase = 0;
+    bool waitingForRelease = false; // set while the F10 bar owns input
+};
+
+std::mutex g_mutex;
+std::array<Slot, kSlotCount> g_slots{};
+std::array<RunState, kSlotCount> g_runStates{};
+
+// Read the physical button straight off the pad, bypassing the port's button
+// mapping. PADGetSDLGamepadForIndex and PADGetIndexForPort are both public, so
+// this needs no change to the pad library itself.
+bool NativeButtonHeld(uint32_t port, uint32_t nativeButton) {
+    if (nativeButton == PAD_NATIVE_BUTTON_INVALID || nativeButton >= SDL_GAMEPAD_BUTTON_COUNT) {
+        return false;
+    }
+    const s32 index = PADGetIndexForPort(port);
+    if (index < 0) {
+        return false;
+    }
+    SDL_Gamepad* gamepad = PADGetSDLGamepadForIndex(static_cast<u32>(index));
+    if (gamepad == nullptr) {
+        return false;
+    }
+    return SDL_GetGamepadButton(gamepad, static_cast<SDL_GamepadButton>(nativeButton));
+}
+
+uint32_t ClampFrames(uint32_t frames) {
+    return std::clamp(frames, kMinFrames, kMaxFrames);
+}
+
+// Turn one Config.toml slot into something the input path can use. Names that do
+// not resolve leave the slot disabled instead of half-configured, so a typo is
+// inert rather than surprising.
+Slot SlotFromConfig(size_t index) {
+    const MacroSetting& setting = RuntimeConfigFile::Macro(index);
+    Slot slot;
+    slot.enabled = setting.enabled;
+    slot.port = setting.port < PAD_CHANMAX ? setting.port : 0;
+    slot.holdFrames = ClampFrames(setting.holdFrames);
+    slot.releaseFrames = ClampFrames(setting.releaseFrames);
+    slot.output = ControllerNames::GameCubeMaskFromKeys(setting.output);
+
+    if (!setting.trigger.empty()) {
+        if (const auto* native = ControllerNames::FindNativeButton(setting.trigger)) {
+            slot.trigger = native->nativeButton;
+        } else {
+            RT_LOG(RT_TAG_CONFIG) << "macro " << (index + 1) << ": unknown trigger button '"
+                                  << setting.trigger << "'" << std::endl;
+        }
+    }
+    if (slot.enabled && !setting.output.empty() && slot.output == 0) {
+        RT_LOG(RT_TAG_CONFIG) << "macro " << (index + 1) << ": no usable output button in '"
+                              << setting.output << "'" << std::endl;
+    }
+    return slot;
+}
+
+void PersistLocked(size_t index, const Slot& slot) {
+    MacroSetting setting;
+    setting.enabled = slot.enabled;
+    setting.port = slot.port;
+    setting.trigger = ControllerNames::NativeButtonForValue(slot.trigger).configName;
+    setting.output = ControllerNames::GameCubeKeysFromMask(slot.output);
+    setting.holdFrames = slot.holdFrames;
+    setting.releaseFrames = slot.releaseFrames;
+    RuntimeConfigFile::SetMacro(index, setting);
+}
+
+// Move a slot one step along its pattern. One step per guest PADRead, which is
+// the game's own once-per-frame input poll. Counting the game's polls rather
+// than video frames guarantees the alternation the game actually sees: every
+// poll flips the state, so a press is always followed by a release even if the
+// renderer stutters or runs ahead.
+void StepPhase(const Slot& slot, RunState& state) {
+    ++state.framesInPhase;
+    const uint32_t phaseLength = state.firing ? slot.holdFrames : slot.releaseFrames;
+    if (state.framesInPhase >= phaseLength) {
+        state.firing = !state.firing;
+        state.framesInPhase = 0;
+    }
+}
+
+} // namespace
+
+void Reload() noexcept {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    for (size_t index = 0; index < kSlotCount; ++index) {
+        g_slots[index] = SlotFromConfig(index);
+        g_runStates[index] = RunState{};
+    }
+}
+
+Slot GetSlot(size_t index) noexcept {
+    if (index >= kSlotCount) {
+        return Slot{};
+    }
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return g_slots[index];
+}
+
+void ApplySlot(size_t index, const Slot& slot) noexcept {
+    if (index >= kSlotCount) {
+        return;
+    }
+    Slot sanitized = slot;
+    sanitized.holdFrames = ClampFrames(sanitized.holdFrames);
+    sanitized.releaseFrames = ClampFrames(sanitized.releaseFrames);
+    if (sanitized.port >= PAD_CHANMAX) {
+        sanitized.port = 0;
+    }
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_slots[index] = sanitized;
+    // Restart the pattern rather than reinterpreting the old phase against new
+    // frame counts, which would let a slot come back mid-press.
+    g_runStates[index] = RunState{};
+}
+
+void PersistSlot(size_t index) noexcept {
+    if (index >= kSlotCount) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_mutex);
+    PersistLocked(index, g_slots[index]);
+}
+
+void SetSlot(size_t index, const Slot& slot) noexcept {
+    ApplySlot(index, slot);
+    PersistSlot(index);
+}
+
+void Apply(std::array<PADStatus, PAD_CHANMAX>& statuses) noexcept {
+    std::lock_guard<std::mutex> lock(g_mutex);
+
+    // The F10 bar takes input away from the game; a macro must not sneak past
+    // that, and it must not resume mid-pattern the moment the bar closes.
+    const bool inputBlocked = PADIsInputBlocked();
+
+    for (size_t index = 0; index < kSlotCount; ++index) {
+        const Slot& slot = g_slots[index];
+        RunState& state = g_runStates[index];
+
+        if (!slot.IsRunnable() || statuses[slot.port].err != PAD_ERR_NONE) {
+            state = RunState{};
+            continue;
+        }
+
+        if (inputBlocked) {
+            state = RunState{};
+            state.waitingForRelease = true;
+            continue;
+        }
+
+        const bool held = NativeButtonHeld(slot.port, slot.trigger);
+
+        // Require the trigger to come back up before a macro re-arms, matching
+        // how PADRead suppresses buttons that were already held when the bar
+        // closed. Without this, letting go of the mouse re-starts the macro.
+        if (state.waitingForRelease) {
+            if (held) {
+                continue;
+            }
+            state.waitingForRelease = false;
+        }
+
+        if (!held) {
+            state = RunState{};
+            continue;
+        }
+
+        if (!state.triggerHeld) {
+            // Fresh press: start on a pressed frame so the first input lands
+            // immediately rather than after a release phase.
+            state.firing = true;
+            state.framesInPhase = 0;
+            state.triggerHeld = true;
+        } else {
+            StepPhase(slot, state);
+        }
+
+        if (state.firing) {
+            statuses[slot.port].button |= slot.output;
+        }
+    }
+}
+
+bool SlotIsFiring(size_t index) noexcept {
+    if (index >= kSlotCount) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return g_runStates[index].firing && g_runStates[index].triggerHeld;
+}
+
+} // namespace InputMacros

--- a/runtime/src/settings_overlay.cpp
+++ b/runtime/src/settings_overlay.cpp
@@ -1,7 +1,9 @@
 #include "settings_overlay.h"
 #include "wup028_adapter.h"
 #include "audio_backend.h"
+#include "controller_button_names.h"
 #include "controller_mapping_wizard.h"
+#include "input_macros.h"
 #include "game_graphics_options.h"
 #include "music_attenuation.h"
 #include "runtime_config.h"
@@ -34,6 +36,10 @@
 #endif
 
 #include <dolphin/pad.h>
+
+// Defined in runtime/src/hle/input/pad.cpp. That directory's headers are not on
+// this target's include path, so declare the one entry point we need.
+extern "C" void PAD_HLE_SetRumbleEnabled(bool enabled);
 #include <dolphin/vi.h>
 #include <aurora/aurora.h>
 #include <aurora/gfx.h>
@@ -76,6 +82,7 @@ int g_voicesVolumePercent = static_cast<int>(std::lround(RuntimeConfigFile::Voic
 bool g_audioMuted = RuntimeConfigFile::AudioMuted(false);
 bool g_audioMixWorker = RuntimeConfigFile::AudioMixWorkerEnabled(true);
 bool g_attenuateMusicWhenMediaPlays = RuntimeConfigFile::AttenuateMusicWhenMediaPlays(false);
+bool g_rumbleEnabled = RuntimeConfigFile::RumbleEnabled(true);
 int g_frameInterpolationMode = [] {
     switch (RuntimeConfigFile::FrameInterpolationFps(0)) {
     case 120:
@@ -106,62 +113,11 @@ std::array<int32_t, PAD_MAX_CONTROLLERS> g_configuredControllerIndices = [] {
     return indices;
 }();
 
-struct ControllerButtonItem {
-    const char* configKey;
-    const char* label;
-    PADButton padButton;
-};
-
-constexpr std::array<ControllerButtonItem, PAD_BUTTON_COUNT> kControllerButtons = {{
-    {"a", "A", PAD_BUTTON_A},
-    {"b", "B", PAD_BUTTON_B},
-    {"x", "X", PAD_BUTTON_X},
-    {"y", "Y", PAD_BUTTON_Y},
-    {"start", "Start", PAD_BUTTON_START},
-    {"z", "Z", PAD_TRIGGER_Z},
-    {"l", "L", PAD_TRIGGER_L},
-    {"r", "R", PAD_TRIGGER_R},
-    {"up", "D-pad Up", PAD_BUTTON_UP},
-    {"down", "D-pad Down", PAD_BUTTON_DOWN},
-    {"left", "D-pad Left", PAD_BUTTON_LEFT},
-    {"right", "D-pad Right", PAD_BUTTON_RIGHT},
-}};
-
-struct NativeButtonItem {
-    const char* configName;
-    const char* label;
-    uint32_t nativeButton;
-};
-
-constexpr std::array<NativeButtonItem, SDL_GAMEPAD_BUTTON_COUNT + 1> kNativeButtons = {{
-    {"unmapped", "Unmapped / analog trigger", PAD_NATIVE_BUTTON_INVALID},
-    {"south", "South (A / Cross)", SDL_GAMEPAD_BUTTON_SOUTH},
-    {"east", "East (B / Circle)", SDL_GAMEPAD_BUTTON_EAST},
-    {"west", "West (X / Square)", SDL_GAMEPAD_BUTTON_WEST},
-    {"north", "North (Y / Triangle)", SDL_GAMEPAD_BUTTON_NORTH},
-    {"back", "Back / Select", SDL_GAMEPAD_BUTTON_BACK},
-    {"guide", "Guide / Home", SDL_GAMEPAD_BUTTON_GUIDE},
-    {"start", "Start / Options", SDL_GAMEPAD_BUTTON_START},
-    {"left_stick", "Left stick click", SDL_GAMEPAD_BUTTON_LEFT_STICK},
-    {"right_stick", "Right stick click", SDL_GAMEPAD_BUTTON_RIGHT_STICK},
-    {"left_shoulder", "Left shoulder", SDL_GAMEPAD_BUTTON_LEFT_SHOULDER},
-    {"right_shoulder", "Right shoulder", SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER},
-    {"dpad_up", "D-pad Up", SDL_GAMEPAD_BUTTON_DPAD_UP},
-    {"dpad_down", "D-pad Down", SDL_GAMEPAD_BUTTON_DPAD_DOWN},
-    {"dpad_left", "D-pad Left", SDL_GAMEPAD_BUTTON_DPAD_LEFT},
-    {"dpad_right", "D-pad Right", SDL_GAMEPAD_BUTTON_DPAD_RIGHT},
-    {"misc1", "Misc 1 / Share", SDL_GAMEPAD_BUTTON_MISC1},
-    {"right_paddle1", "Right paddle 1", SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1},
-    {"left_paddle1", "Left paddle 1", SDL_GAMEPAD_BUTTON_LEFT_PADDLE1},
-    {"right_paddle2", "Right paddle 2", SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2},
-    {"left_paddle2", "Left paddle 2", SDL_GAMEPAD_BUTTON_LEFT_PADDLE2},
-    {"touchpad", "Touchpad", SDL_GAMEPAD_BUTTON_TOUCHPAD},
-    {"misc2", "Misc 2", SDL_GAMEPAD_BUTTON_MISC2},
-    {"misc3", "Misc 3 / GC L click", SDL_GAMEPAD_BUTTON_MISC3},
-    {"misc4", "Misc 4 / GC R click", SDL_GAMEPAD_BUTTON_MISC4},
-    {"misc5", "Misc 5", SDL_GAMEPAD_BUTTON_MISC5},
-    {"misc6", "Misc 6", SDL_GAMEPAD_BUTTON_MISC6},
-}};
+using ControllerNames::kNativeButtons;
+using ControllerNames::NativeButtonItem;
+// The GameCube button table is indexed positionally by the config writer and by
+// every preset below, so keep the short name the rest of this file already uses.
+constexpr const auto& kControllerButtons = ControllerNames::kGameCubeButtons;
 
 // Classic Controller Pro layout, indexed like kControllerButtons: the SNES-style
 // diamond (A right, B bottom, X top, Y left) with digital bumpers driving the GC
@@ -175,6 +131,24 @@ constexpr std::array<const char*, PAD_BUTTON_COUNT> kClassicProPreset = {
     "back",           // Z
     "left_shoulder",  // L
     "right_shoulder", // R
+    "dpad_up", "dpad_down", "dpad_left", "dpad_right",
+};
+
+// PlayStation layout. The stock defaults leave L1 unbound and park Z on R1,
+// which wastes both bumpers on a pad whose analog triggers already cover L and
+// R. This puts the bumpers on the GC triggers, where they are the fastest
+// digital press available, and moves Z to Create/Share alongside the other
+// presets. L2/R2 keep working as analog pulls; they just no longer produce the
+// digital click, because the bumpers own it.
+constexpr std::array<const char*, PAD_BUTTON_COUNT> kPlayStationPreset = {
+    "south",          // A  (Cross)
+    "east",           // B  (Circle)
+    "west",           // X  (Square)
+    "north",          // Y  (Triangle)
+    "start",          // Start (Options)
+    "back",           // Z  (Create / Share)
+    "left_shoulder",  // L  (L1)
+    "right_shoulder", // R  (R1)
     "dpad_up", "dpad_down", "dpad_left", "dpad_right",
 };
 
@@ -225,43 +199,25 @@ void LimitResolutionForFrameRate() {
     }
 }
 
-const NativeButtonItem* FindNativeButton(std::string value) {
-    const auto it = std::find_if(kNativeButtons.begin(), kNativeButtons.end(), [&](const NativeButtonItem& item) {
-        return value == item.configName;
-    });
-    return it == kNativeButtons.end() ? nullptr : &*it;
-}
+using ControllerNames::FindNativeButton;
 
 struct ControllerBindingPair {
     std::string primary;
     std::string secondary;
 };
 
-std::string TrimBindingToken(const std::string& token) {
-    const size_t begin = token.find_first_not_of(" \t");
-    if (begin == std::string::npos) {
-        return {};
-    }
-    const size_t end = token.find_last_not_of(" \t");
-    return token.substr(begin, end - begin + 1);
-}
 
 // Config values hold up to two comma-separated button names ("dpad_up" or
 // "dpad_up,left_shoulder"); pressing either one counts as the GC button.
 ControllerBindingPair SplitControllerBinding(const std::string& value) {
     const size_t comma = value.find(',');
     if (comma == std::string::npos) {
-        return {TrimBindingToken(value), {}};
+        return {ControllerNames::TrimToken(value), {}};
     }
-    return {TrimBindingToken(value.substr(0, comma)), TrimBindingToken(value.substr(comma + 1))};
+    return {ControllerNames::TrimToken(value.substr(0, comma)), ControllerNames::TrimToken(value.substr(comma + 1))};
 }
 
-const NativeButtonItem& NativeButtonForValue(uint32_t nativeButton) {
-    const auto it = std::find_if(kNativeButtons.begin(), kNativeButtons.end(), [&](const NativeButtonItem& item) {
-        return nativeButton == item.nativeButton;
-    });
-    return it == kNativeButtons.end() ? kNativeButtons.front() : *it;
-}
+using ControllerNames::NativeButtonForValue;
 
 void SetTopBarVisible(bool visible) {
     if (g_topBarVisible == visible) {
@@ -340,6 +296,154 @@ void DrawGameCubeAdapterInfo() {
     ImGui::EndMenu();
 }
 
+// Frames-per-cycle limits mirror InputMacros so the slider cannot produce a
+// value the engine would silently clamp.
+void DrawMacroSettings() {
+    ImGui::SeparatorText("Macros");
+    ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + 420.0f);
+    ImGui::TextDisabled(
+        "Hold a button to repeat a GameCube input on a frame pattern. Frames are "
+        "game frames, counted independently of frame interpolation. The game only "
+        "sees a new press after a release, so 1 held / 1 released is the fastest "
+        "useful repeat.");
+    ImGui::PopTextWrapPos();
+
+    for (size_t slotIndex = 0; slotIndex < InputMacros::kSlotCount; ++slotIndex) {
+        InputMacros::Slot slot = InputMacros::GetSlot(slotIndex);
+        // Offset past the button-mapping rows above, which push IDs 0..11 at
+        // this same level of the widget stack.
+        ImGui::PushID(static_cast<int>(slotIndex) + 1000);
+
+        bool enabled = slot.enabled;
+        const std::string label = "Macro " + std::to_string(slotIndex + 1);
+        if (ImGui::Checkbox(label.c_str(), &enabled)) {
+            slot.enabled = enabled;
+            InputMacros::SetSlot(slotIndex, slot);
+        }
+
+        // Live feedback: the only way to tell a working macro from a mis-bound
+        // one without leaving the menu.
+        if (slot.IsRunnable()) {
+            const bool firing = InputMacros::SlotIsFiring(slotIndex);
+            ImGui::SameLine();
+            ImGui::TextColored(firing ? ImVec4(0.4f, 0.9f, 0.4f, 1.0f) : ImVec4(0.5f, 0.5f, 0.5f, 1.0f), "%s",
+                               firing ? "firing" : "idle");
+        }
+
+        if (!enabled) {
+            ImGui::PopID();
+            continue;
+        }
+
+        ImGui::Indent();
+
+        int port = static_cast<int>(slot.port);
+        ImGui::SetNextItemWidth(120.0f);
+        if (ImGui::Combo("Port", &port, "Port 1\0Port 2\0Port 3\0Port 4\0")) {
+            slot.port = static_cast<uint32_t>(port);
+            InputMacros::SetSlot(slotIndex, slot);
+        }
+
+        ImGui::SetNextItemWidth(190.0f);
+        if (ImGui::BeginCombo("Hold", NativeButtonForValue(slot.trigger).label)) {
+            for (const auto& candidate : kNativeButtons) {
+                const bool selected = candidate.nativeButton == slot.trigger;
+                const bool isNone = candidate.nativeButton == PAD_NATIVE_BUTTON_INVALID;
+                if (ImGui::Selectable(isNone ? "None" : candidate.label, selected)) {
+                    slot.trigger = candidate.nativeButton;
+                    InputMacros::SetSlot(slotIndex, slot);
+                }
+                if (selected) {
+                    ImGui::SetItemDefaultFocus();
+                }
+            }
+            ImGui::EndCombo();
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(
+                "The physical button that runs the macro. If it is also bound to a\n"
+                "GameCube button above, both still happen; set that binding to\n"
+                "\"Unmapped\" to make this button macro-only.");
+        }
+
+        // Outputs are a bitmask, so this is a multi-select rather than a combo.
+        ImGui::SetNextItemWidth(190.0f);
+        if (ImGui::BeginCombo("Send", ControllerNames::GameCubeLabelsFromMask(slot.output).c_str())) {
+            for (const auto& candidate : kControllerButtons) {
+                const auto bit = static_cast<uint16_t>(candidate.padButton);
+                const bool selected = (slot.output & bit) != 0;
+                if (ImGui::Selectable(candidate.label, selected, ImGuiSelectableFlags_NoAutoClosePopups)) {
+                    slot.output = static_cast<uint16_t>(selected ? (slot.output & ~bit) : (slot.output | bit));
+                    InputMacros::SetSlot(slotIndex, slot);
+                }
+            }
+            ImGui::EndCombo();
+        }
+
+        // Sliders change every frame while dragged. Applying is cheap; writing
+        // is not, since each persist rewrites the whole Config.toml. So apply
+        // live and save once, when the drag ends.
+        int holdFrames = static_cast<int>(slot.holdFrames);
+        ImGui::SetNextItemWidth(190.0f);
+        if (ImGui::SliderInt("Frames held", &holdFrames, static_cast<int>(InputMacros::kMinFrames),
+                             static_cast<int>(InputMacros::kMaxFrames))) {
+            slot.holdFrames = static_cast<uint32_t>(holdFrames);
+            InputMacros::ApplySlot(slotIndex, slot);
+        }
+        if (ImGui::IsItemDeactivatedAfterEdit()) {
+            InputMacros::PersistSlot(slotIndex);
+        }
+
+        int releaseFrames = static_cast<int>(slot.releaseFrames);
+        ImGui::SetNextItemWidth(190.0f);
+        if (ImGui::SliderInt("Frames released", &releaseFrames, static_cast<int>(InputMacros::kMinFrames),
+                             static_cast<int>(InputMacros::kMaxFrames))) {
+            slot.releaseFrames = static_cast<uint32_t>(releaseFrames);
+            InputMacros::ApplySlot(slotIndex, slot);
+        }
+        if (ImGui::IsItemDeactivatedAfterEdit()) {
+            InputMacros::PersistSlot(slotIndex);
+        }
+
+        // Lead with the frame count, which is exact. The per-second figure
+        // assumes a 60 Hz video mode and would be wrong on a 50 Hz PAL boot.
+        const uint32_t cycleFrames = slot.holdFrames + slot.releaseFrames;
+        ImGui::TextDisabled("One press every %u frames (%.1f per second at 60 fps)", cycleFrames,
+                            60.0f / static_cast<float>(cycleFrames));
+
+        if (slot.output == 0) {
+            ImGui::TextColored(ImVec4(1.0f, 0.65f, 0.3f, 1.0f), "Pick at least one button to send.");
+        } else if (slot.trigger == PAD_NATIVE_BUTTON_INVALID) {
+            ImGui::TextColored(ImVec4(1.0f, 0.65f, 0.3f, 1.0f), "Pick a button to hold.");
+        }
+
+        ImGui::Unindent();
+        ImGui::PopID();
+    }
+}
+
+void DrawRumbleSettings() {
+    ImGui::SeparatorText("Vibration");
+    if (ImGui::Checkbox("Controller vibration", &g_rumbleEnabled)) {
+        PAD_HLE_SetRumbleEnabled(g_rumbleEnabled);
+        RuntimeConfigFile::SetRumbleEnabled(g_rumbleEnabled);
+        if (!g_rumbleEnabled) {
+            // Stop whatever is already running: the game will not send another
+            // motor command until its own state machine decides to.
+            constexpr std::array<uint32_t, PAD_MAX_CONTROLLERS> stopAll{
+                PAD_MOTOR_STOP_HARD, PAD_MOTOR_STOP_HARD, PAD_MOTOR_STOP_HARD, PAD_MOTOR_STOP_HARD,
+            };
+            PADControlAllMotors(stopAll.data());
+            for (uint32_t port = 0; port < PAD_MAX_CONTROLLERS; ++port) {
+                Wup028Adapter::SetRumble(port, false);
+            }
+        }
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Applies to every port, including controllers on a GameCube adapter.");
+    }
+}
+
 void DrawControllerSettings() {
     for (int port = 0; port < PAD_MAX_CONTROLLERS; ++port) {
         const std::string label = "Port " + std::to_string(port + 1);
@@ -406,6 +510,8 @@ void DrawControllerSettings() {
                 PADSetPortForIndex(index, selectedGamePort);
                 g_configuredControllerIndices.fill(std::numeric_limits<int32_t>::min());
                 ApplyConfiguredMappings();
+    InputMacros::Reload();
+    PAD_HLE_SetRumbleEnabled(g_rumbleEnabled);
             }
             ImGui::PopID();
         }
@@ -461,20 +567,34 @@ void DrawControllerSettings() {
         PADSerializeMappings();
         mappings = PADGetButtonMappings(port, &mappingCount);
     }
-    ImGui::SameLine();
-    if (ImGui::Button("Classic Controller Pro")) {
+    // Presets that are just a list of physical button names all apply the same
+    // way: overwrite every primary binding, clear the secondaries, persist.
+    const auto applyPreset = [&](const std::array<const char*, PAD_BUTTON_COUNT>& preset) {
         const uint32_t port = static_cast<uint32_t>(g_controllerPort);
         for (size_t i = 0; i < kControllerButtons.size(); ++i) {
-            if (const NativeButtonItem* native = FindNativeButton(kClassicProPreset[i])) {
+            if (const NativeButtonItem* native = FindNativeButton(preset[i])) {
                 PADSetButtonMapping(port, PADButtonMapping{native->nativeButton, kControllerButtons[i].padButton});
                 PADSetAltButtonMapping(port,
                                        PADButtonMapping{PAD_NATIVE_BUTTON_INVALID, kControllerButtons[i].padButton});
-                RuntimeConfigFile::SetControllerButton(i, kClassicProPreset[i]);
+                RuntimeConfigFile::SetControllerButton(i, preset[i]);
             }
         }
         altRowExpanded.fill(false);
         PADSerializeMappings();
         mappings = PADGetButtonMappings(port, &mappingCount);
+    };
+
+    ImGui::SameLine();
+    if (ImGui::Button("Classic Controller Pro")) {
+        applyPreset(kClassicProPreset);
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("PlayStation")) {
+        applyPreset(kPlayStationPreset);
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Puts L and R on the bumpers (L1/R1) and Z on Create/Share.\n"
+                          "L2/R2 still pull the analog triggers.");
     }
 
     ImGui::SeparatorText("Button mapping");
@@ -556,6 +676,8 @@ void DrawControllerSettings() {
         ImGui::TextUnformatted(kControllerButtons[i].label);
         ImGui::PopID();
     }
+    DrawMacroSettings();
+    DrawRumbleSettings();
     DrawGameCubeAdapterInfo();
 }
 


### PR DESCRIPTION
Adds three controller features, all in runtime/ with no changes to aurora-main, so the precompiled aurora package does not need regenerating.

- Input macros: hold a physical button to repeat a set of GameCube buttons on a hold/release frame pattern. The pattern advances once per guest PADRead, which is the game's own input poll, so it is unaffected by frame interpolation and every press is separated by a release the game can see. Four slots, configured in the F10 bar and persisted to Config.toml.

- Bumper handling (fixes https://github.com/patchzyy/Wiicompiled/issues/74): a new PlayStation preset puts L and R on L1/R1, and a digital button bound to L or R now reports a fully pulled analog trigger, matching real hardware where the click only engages at full depression.

- Vibration toggle: turns force feedback off for every port, including controllers on a GameCube adapter.

Button name tables move to runtime/include/controller_button_names.h so the settings bar and the macro loader share one vocabulary.

<img width="436" height="799" alt="image" src="https://github.com/user-attachments/assets/a6e233e1-0acc-42e1-8c3a-d506d198e0d1" />