### PR TITLE
bring back auto-assignment

### DIFF
--- a/aurora-main/lib/input.cpp
+++ b/aurora-main/lib/input.cpp
@@ -329,18 +329,6 @@ void apply_port_preferences() noexcept {
   }
 }
 
-#if defined(_WIN32)
-// Ports are explicit assignments. SDL may choose a player index at connection
-// time, but accepting it would make a newly connected controller silently take
-// over a game port before the user assigns it in the controller menu - which
-// matters here because a manually-assigned WUP-028 adapter port (see
-// wup028_adapter.cpp, Windows-only) could otherwise collide with one SDL
-// auto-claimed. Elsewhere, with no WUP-028 port to collide with, the original
-// auto-claim behavior below is restored instead.
-void ensure_player_index(GameController& controller) noexcept {
-  assign_player_index(controller, -1);
-}
-#else
 // SDL only hands out a player index when the device already had a gamepad mapping
 // at connect time, so anything mapped later (the setup wizard) stays at -1.
 void ensure_player_index(GameController& controller) noexcept {
@@ -374,7 +362,6 @@ void ensure_player_index(GameController& controller) noexcept {
     claim(false);
   }
 }
-#endif
 } // namespace
 
 GameController* get_controller_for_player(uint32_t player) noexcept {

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -59,6 +59,7 @@
 #include <aurora/aurora.h>
 #include <aurora/gfx.h>
 #include <dolphin/gx/GXAurora.h>
+#include <dolphin/pad.h>
 #include <dolphin/vi.h>
 
 // Defined in `runtime/src/hle/vi.cpp` (used by GX/VI HLE).
@@ -1379,6 +1380,9 @@ int RuntimeMain(int argc, char** argv) {
         GxGuestWrite::InstallAuroraHooks();
 #if defined(_WIN32)
         Wup028Adapter::Initialize();
+        for (uint32_t port = 0; port < PAD_CHANMAX; ++port) {
+            if (Wup028Adapter::GetPortAssignment(port) >= 0) PADClearPort(port);
+        }
 #endif
         UpdateMkwDynamicAspectSurface(auroraInfo.windowSize.native_fb_width,
                                       auroraInfo.windowSize.native_fb_height);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller port assignment on Windows to preserve existing indices and prioritize available ports.
  * Cleared assigned controller ports during Windows startup to prevent stale controller connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->