### PR TITLE
feature(input): racing wheel support with force feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,25 @@ The official Wii U / Switch GameCube adapter (WUP-028) works too; as with Dolphi
 adapter must be switched to the WinUSB driver once (Zadig).
 
 **Racing wheels.** 
-Logitech Driving Force wheels (G29, G27, G25, DFGT, DFP, Driving Force, MOMO, G920, G923) are
-recognized on their own. Plug one in and it gets a layout, a port and force feedback with no setup:
-the accelerator and brake pedals are A and B, the paddles are L and R, the wheel steers, and the
-clutch is left alone. Install Logitech G HUB first and turn Combined Pedals off. A wheel the
-runtime does not know still shows up under *Unrecognized controllers* with a **Set up** button, and
-so does any wheel whose built-in layout you want to replace, since a mapping you capture yourself
-wins over the built-in one.
+Any wheel SDL knows is treated as a wheel: the Logitech Driving Force line, Thrustmaster, Fanatec,
+Moza, Simagic, Simucube, Asetek, Cammus, PXN and others. That gets you force feedback, steering that
+uses the whole rotation of the wheel, and pedals on A and B. Pedal axes are worked out at runtime by
+watching which ones sit at rest and which travel, so a wheel does not need to be in any list here to
+work, and wheels that put both pedals on one axis are handled too.
+
+Logitech Driving Force wheels also get a full button layout without any setup, since their layout is
+known. Other wheels play immediately but their buttons come from the **Set up** wizard under
+*Unrecognized controllers* in **F10**, **Controller settings**; a mapping you capture there wins
+over anything built in. If the pedals come out the wrong way round, which happens because no two
+brands agree on axis order, set Accelerator and Brake in that same menu instead of running the
+wizard.
 
 Force feedback is a centering spring that loads up as you steer, plus vibration from the game's own
-rumble. **F10**, **Controller settings** has sliders for steering sensitivity, strength, spring and
-vibration; they apply as you drag and are saved to `Config.toml`. Set the wheel's rotation range in
-G HUB, around 270 degrees suits a kart game better than the default 900. The G29 is what this was
-built and tested against; the G920 and G923 have force feedback problems in SDL itself. Other
-brands can be tried with `force_wheel = true` under `[ffb]`.
+rumble. The same menu has sliders for steering sensitivity, strength, spring and vibration; they
+apply as you drag and are saved to `Config.toml`. Set the wheel's rotation range in the wheel's own
+driver, around 270 degrees suits a kart game better than the usual 900. The G29 is what this was
+built and tested against. The G920 and G923 have force feedback problems in SDL itself, and a wheel
+SDL does not recognize at all can be forced with `force_wheel = true` under `[ffb]`.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ inputs like paddles, touchpads and share buttons show up when the hardware repor
 The official Wii U / Switch GameCube adapter (WUP-028) works too; as with Dolphin, on Windows the
 adapter must be switched to the WinUSB driver once (Zadig).
 
+**Racing wheels (Logitech G29 / Driving Force and similar).**
+Wheels are not gamepads, so SDL has no built-in layout for them. Install Logitech G HUB (or the
+older Logitech Gaming Software) and turn combined pedals off. Then press **F10**, open
+**Controller settings**, and pick **Set up** next to the wheel under *Unrecognized controllers*.
+The wizard asks for each control in turn: press the throttle pedal for A, the brake pedal for B, a
+paddle for L and R, and turn the wheel left for the Control Stick; skip anything the wheel does not
+have. The mapping is saved to `gamecontrollerdb.txt` next to `Config.toml` and reused on later
+launches. The same menu has sliders for the stick dead zone (lower it so the wheel responds around
+centre), the L/R press point, and rumble strength; the game's rumble reaches a force-feedback wheel
+as a vibration effect, so start low. Set the wheel's rotation range in G HUB, around 270° feels
+closest to a stick. Real force feedback is not driven.
+
 ## Requirements
 
 - Windows 10 or 11, 64-bit

--- a/README.md
+++ b/README.md
@@ -60,26 +60,21 @@ inputs like paddles, touchpads and share buttons show up when the hardware repor
 The official Wii U / Switch GameCube adapter (WUP-028) works too; as with Dolphin, on Windows the
 adapter must be switched to the WinUSB driver once (Zadig).
 
-**Racing wheels (Logitech G29 / Driving Force and similar).**
-Wheels are not gamepads, so SDL has no built-in layout for them. Install Logitech G HUB (or the
-older Logitech Gaming Software) and turn combined pedals off. Then press **F10**, open
-**Controller settings**, and pick **Set up** next to the wheel under *Unrecognized controllers*.
-The wizard asks for each control in turn: press the throttle pedal for A, the brake pedal for B, a
-paddle for L and R, and turn the wheel left for the Control Stick; skip anything the wheel does not
-have. The mapping is saved to `gamecontrollerdb.txt` next to `Config.toml` and reused on later
-launches. The same menu has sliders for the stick dead zone (lower it so the wheel responds around
-centre), the L/R press point, and rumble strength.
+**Racing wheels.** 
+Logitech Driving Force wheels (G29, G27, G25, DFGT, DFP, Driving Force, MOMO, G920, G923) are
+recognized on their own. Plug one in and it gets a layout, a port and force feedback with no setup:
+the accelerator and brake pedals are A and B, the paddles are L and R, the wheel steers, and the
+clutch is left alone. Install Logitech G HUB first and turn Combined Pedals off. A wheel the
+runtime does not know still shows up under *Unrecognized controllers* with a **Set up** button, and
+so does any wheel whose built-in layout you want to replace, since a mapping you capture yourself
+wins over the built-in one.
 
-**Force feedback.**
-Wheels from the Logitech Driving Force family (Driving Force, DFP, DFGT, G25, G27, G29, G920,
-G923, PRO, MOMO and the WingMan wheels) get a real force-feedback section under **F10 →
-Controller settings**: a centering spring so the wheel loads up as you steer, vibration driven by
-the game's own rumble (collisions, off-road, boosts), and an overall strength slider. Everything is
-saved to `Config.toml` and applied live. Forces keep working when the window loses focus. Set the
-wheel's rotation range in G HUB, around 270° feels closest to a stick. Other brands of FFB wheel
-can be tried with `force_wheel = true` under `[ffb]` in `Config.toml`; known-good IDs get added to
-the wheel table over time. The G29 family is the tested baseline; G920/G923 have known
-force-feedback issues in the underlying SDL library.
+Force feedback is a centering spring that loads up as you steer, plus vibration from the game's own
+rumble. **F10**, **Controller settings** has sliders for steering sensitivity, strength, spring and
+vibration; they apply as you drag and are saved to `Config.toml`. Set the wheel's rotation range in
+G HUB, around 270 degrees suits a kart game better than the default 900. The G29 is what this was
+built and tested against; the G920 and G923 have force feedback problems in SDL itself. Other
+brands can be tried with `force_wheel = true` under `[ffb]`.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,18 @@ The wizard asks for each control in turn: press the throttle pedal for A, the br
 paddle for L and R, and turn the wheel left for the Control Stick; skip anything the wheel does not
 have. The mapping is saved to `gamecontrollerdb.txt` next to `Config.toml` and reused on later
 launches. The same menu has sliders for the stick dead zone (lower it so the wheel responds around
-centre), the L/R press point, and rumble strength; the game's rumble reaches a force-feedback wheel
-as a vibration effect, so start low. Set the wheel's rotation range in G HUB, around 270° feels
-closest to a stick. Real force feedback is not driven.
+centre), the L/R press point, and rumble strength.
+
+**Force feedback.**
+Wheels from the Logitech Driving Force family (Driving Force, DFP, DFGT, G25, G27, G29, G920,
+G923, PRO, MOMO and the WingMan wheels) get a real force-feedback section under **F10 →
+Controller settings**: a centering spring so the wheel loads up as you steer, vibration driven by
+the game's own rumble (collisions, off-road, boosts), and an overall strength slider. Everything is
+saved to `Config.toml` and applied live. Forces keep working when the window loses focus. Set the
+wheel's rotation range in G HUB, around 270° feels closest to a stick. Other brands of FFB wheel
+can be tried with `force_wheel = true` under `[ffb]` in `Config.toml`; known-good IDs get added to
+the wheel table over time. The G29 family is the tested baseline; G920/G923 have known
+force-feedback issues in the underlying SDL library.
 
 ## Requirements
 

--- a/runtime/include/controller_mapping_wizard.h
+++ b/runtime/include/controller_mapping_wizard.h
@@ -9,6 +9,7 @@
 namespace controller_mapping_wizard {
 
 void LoadPersistedMappings();
+void ApplyBuiltinWheelMappings();
 void HandleSdlEvent(const SDL_Event& event);
 
 // Lists devices that need setup inside the controller settings menu.

--- a/runtime/include/runtime_config.h
+++ b/runtime/include/runtime_config.h
@@ -69,6 +69,8 @@ struct RuntimeUserConfig {
     std::optional<int32_t> ffbVibration;
     std::optional<bool> ffbForceWheel;
     std::optional<int32_t> steeringSensitivity;
+    std::optional<int32_t> acceleratorAxis;
+    std::optional<int32_t> brakeAxis;
 };
 
 namespace RuntimeConfigFile {
@@ -375,6 +377,8 @@ inline RuntimeUserConfig ParseConfigDocument(const toml::value& document) {
     config.ffbVibration = FindConfigInt(document, "ffb", "vibration");
     config.ffbForceWheel = FindConfigValue<bool>(document, "ffb", "force_wheel");
     config.steeringSensitivity = FindConfigInt(document, "controller", "steering_sensitivity");
+    config.acceleratorAxis = FindConfigInt(document, "controller", "accelerator_axis");
+    config.brakeAxis = FindConfigInt(document, "controller", "brake_axis");
 
     config.widescreen = FindConfigValue<bool>(document, "video", "widescreen");
     config.windowPosX = FindConfigInt(document, "video", "window_x");
@@ -499,6 +503,14 @@ inline int32_t FfbVibration(int32_t fallback = 70) {
 
 inline bool FfbForceWheel(bool fallback = false) {
     return Get().ffbForceWheel.value_or(fallback);
+}
+
+inline int32_t AcceleratorAxis(int32_t fallback = -1) {
+    return std::clamp(Get().acceleratorAxis.value_or(fallback), -1, 7);
+}
+
+inline int32_t BrakeAxis(int32_t fallback = -1) {
+    return std::clamp(Get().brakeAxis.value_or(fallback), -1, 7);
 }
 
 inline int32_t SteeringSensitivity(int32_t fallback = 350) {
@@ -675,6 +687,18 @@ inline bool SetFfbSpring(int32_t value) {
     value = std::clamp(value, 0, 100);
     Mutable().ffbSpring = value;
     return WriteSetting("ffb", "spring", std::to_string(value));
+}
+
+inline bool SetAcceleratorAxis(int32_t value) {
+    value = std::clamp(value, -1, 7);
+    Mutable().acceleratorAxis = value;
+    return WriteSetting("controller", "accelerator_axis", std::to_string(value));
+}
+
+inline bool SetBrakeAxis(int32_t value) {
+    value = std::clamp(value, -1, 7);
+    Mutable().brakeAxis = value;
+    return WriteSetting("controller", "brake_axis", std::to_string(value));
 }
 
 inline bool SetSteeringSensitivity(int32_t value) {

--- a/runtime/include/runtime_config.h
+++ b/runtime/include/runtime_config.h
@@ -501,8 +501,8 @@ inline bool FfbForceWheel(bool fallback = false) {
     return Get().ffbForceWheel.value_or(fallback);
 }
 
-inline int32_t SteeringSensitivity(int32_t fallback = 200) {
-    return std::clamp(Get().steeringSensitivity.value_or(fallback), 100, 400);
+inline int32_t SteeringSensitivity(int32_t fallback = 350) {
+    return std::clamp(Get().steeringSensitivity.value_or(fallback), 100, 900);
 }
 
 // Update one TOML value without discarding comments, unrelated settings, or
@@ -678,7 +678,7 @@ inline bool SetFfbSpring(int32_t value) {
 }
 
 inline bool SetSteeringSensitivity(int32_t value) {
-    value = std::clamp(value, 100, 400);
+    value = std::clamp(value, 100, 900);
     Mutable().steeringSensitivity = value;
     return WriteSetting("controller", "steering_sensitivity", std::to_string(value));
 }

--- a/runtime/include/runtime_config.h
+++ b/runtime/include/runtime_config.h
@@ -68,6 +68,7 @@ struct RuntimeUserConfig {
     std::optional<int32_t> ffbSpring;
     std::optional<int32_t> ffbVibration;
     std::optional<bool> ffbForceWheel;
+    std::optional<int32_t> steeringSensitivity;
 };
 
 namespace RuntimeConfigFile {
@@ -373,6 +374,7 @@ inline RuntimeUserConfig ParseConfigDocument(const toml::value& document) {
     config.ffbSpring = FindConfigInt(document, "ffb", "spring");
     config.ffbVibration = FindConfigInt(document, "ffb", "vibration");
     config.ffbForceWheel = FindConfigValue<bool>(document, "ffb", "force_wheel");
+    config.steeringSensitivity = FindConfigInt(document, "controller", "steering_sensitivity");
 
     config.widescreen = FindConfigValue<bool>(document, "video", "widescreen");
     config.windowPosX = FindConfigInt(document, "video", "window_x");
@@ -497,6 +499,10 @@ inline int32_t FfbVibration(int32_t fallback = 70) {
 
 inline bool FfbForceWheel(bool fallback = false) {
     return Get().ffbForceWheel.value_or(fallback);
+}
+
+inline int32_t SteeringSensitivity(int32_t fallback = 200) {
+    return std::clamp(Get().steeringSensitivity.value_or(fallback), 100, 400);
 }
 
 // Update one TOML value without discarding comments, unrelated settings, or
@@ -669,6 +675,12 @@ inline bool SetFfbSpring(int32_t value) {
     value = std::clamp(value, 0, 100);
     Mutable().ffbSpring = value;
     return WriteSetting("ffb", "spring", std::to_string(value));
+}
+
+inline bool SetSteeringSensitivity(int32_t value) {
+    value = std::clamp(value, 100, 400);
+    Mutable().steeringSensitivity = value;
+    return WriteSetting("controller", "steering_sensitivity", std::to_string(value));
 }
 
 inline bool SetFfbVibration(int32_t value) {

--- a/runtime/include/runtime_config.h
+++ b/runtime/include/runtime_config.h
@@ -506,11 +506,13 @@ inline bool FfbForceWheel(bool fallback = false) {
 }
 
 inline int32_t AcceleratorAxis(int32_t fallback = -1) {
-    return std::clamp(Get().acceleratorAxis.value_or(fallback), -1, 7);
+    const int32_t value = Get().acceleratorAxis.value_or(fallback);
+    return value >= 1 && value <= 7 ? value : -1;
 }
 
 inline int32_t BrakeAxis(int32_t fallback = -1) {
-    return std::clamp(Get().brakeAxis.value_or(fallback), -1, 7);
+    const int32_t value = Get().brakeAxis.value_or(fallback);
+    return value >= 1 && value <= 7 ? value : -1;
 }
 
 inline int32_t SteeringSensitivity(int32_t fallback = 350) {
@@ -690,13 +692,13 @@ inline bool SetFfbSpring(int32_t value) {
 }
 
 inline bool SetAcceleratorAxis(int32_t value) {
-    value = std::clamp(value, -1, 7);
+    value = value >= 1 && value <= 7 ? value : -1;
     Mutable().acceleratorAxis = value;
     return WriteSetting("controller", "accelerator_axis", std::to_string(value));
 }
 
 inline bool SetBrakeAxis(int32_t value) {
-    value = std::clamp(value, -1, 7);
+    value = value >= 1 && value <= 7 ? value : -1;
     Mutable().brakeAxis = value;
     return WriteSetting("controller", "brake_axis", std::to_string(value));
 }

--- a/runtime/include/runtime_config.h
+++ b/runtime/include/runtime_config.h
@@ -63,6 +63,11 @@ struct RuntimeUserConfig {
     // comma-separated SDL-style physical button names ("south", or
     // "dpad_up,left_shoulder") as values; pressing either bound button counts.
     std::array<std::optional<std::string>, 12> controllerButtons;
+    std::optional<bool> ffbEnabled;
+    std::optional<int32_t> ffbStrength;
+    std::optional<int32_t> ffbSpring;
+    std::optional<int32_t> ffbVibration;
+    std::optional<bool> ffbForceWheel;
 };
 
 namespace RuntimeConfigFile {
@@ -363,6 +368,12 @@ inline RuntimeUserConfig ParseConfigDocument(const toml::value& document) {
             FindConfigValue<std::string>(document, "controller", buttonKeys[index]);
     }
 
+    config.ffbEnabled = FindConfigValue<bool>(document, "ffb", "enabled");
+    config.ffbStrength = FindConfigInt(document, "ffb", "strength");
+    config.ffbSpring = FindConfigInt(document, "ffb", "spring");
+    config.ffbVibration = FindConfigInt(document, "ffb", "vibration");
+    config.ffbForceWheel = FindConfigValue<bool>(document, "ffb", "force_wheel");
+
     config.widescreen = FindConfigValue<bool>(document, "video", "widescreen");
     config.windowPosX = FindConfigInt(document, "video", "window_x");
     config.windowPosY = FindConfigInt(document, "video", "window_y");
@@ -468,6 +479,24 @@ inline constexpr std::array<std::string_view, 12> kControllerButtonKeys = {
 inline const std::optional<std::string>& ControllerButton(size_t index) {
     static const std::optional<std::string> empty;
     return index < Get().controllerButtons.size() ? Get().controllerButtons[index] : empty;
+}
+
+inline bool FfbEnabled(bool fallback = true) { return Get().ffbEnabled.value_or(fallback); }
+
+inline int32_t FfbStrength(int32_t fallback = 100) {
+    return std::clamp(Get().ffbStrength.value_or(fallback), 0, 100);
+}
+
+inline int32_t FfbSpring(int32_t fallback = 60) {
+    return std::clamp(Get().ffbSpring.value_or(fallback), 0, 100);
+}
+
+inline int32_t FfbVibration(int32_t fallback = 70) {
+    return std::clamp(Get().ffbVibration.value_or(fallback), 0, 100);
+}
+
+inline bool FfbForceWheel(bool fallback = false) {
+    return Get().ffbForceWheel.value_or(fallback);
 }
 
 // Update one TOML value without discarding comments, unrelated settings, or
@@ -623,6 +652,29 @@ inline bool SetControllerButton(size_t index, std::string value) {
     }
     Mutable().controllerButtons[index] = value;
     return WriteSetting("controller", kControllerButtonKeys[index], FormatString(value));
+}
+
+inline bool SetFfbEnabled(bool value) {
+    Mutable().ffbEnabled = value;
+    return WriteSetting("ffb", "enabled", value ? "true" : "false");
+}
+
+inline bool SetFfbStrength(int32_t value) {
+    value = std::clamp(value, 0, 100);
+    Mutable().ffbStrength = value;
+    return WriteSetting("ffb", "strength", std::to_string(value));
+}
+
+inline bool SetFfbSpring(int32_t value) {
+    value = std::clamp(value, 0, 100);
+    Mutable().ffbSpring = value;
+    return WriteSetting("ffb", "spring", std::to_string(value));
+}
+
+inline bool SetFfbVibration(int32_t value) {
+    value = std::clamp(value, 0, 100);
+    Mutable().ffbVibration = value;
+    return WriteSetting("ffb", "vibration", std::to_string(value));
 }
 
 inline bool SetAudioVolume(float value) {

--- a/runtime/include/wheel_ffb.h
+++ b/runtime/include/wheel_ffb.h
@@ -4,7 +4,8 @@
 
 namespace wheel_ffb {
 
-bool IsWheelDevice(uint16_t vendor, uint16_t product);
+bool IsWheelInstance(uint32_t instance);
+bool HasBuiltinLayout(uint32_t instance);
 uint32_t PedalButtons(uint32_t port);
 void NotifyControllersChanged();
 void Tick();

--- a/runtime/include/wheel_ffb.h
+++ b/runtime/include/wheel_ffb.h
@@ -4,9 +4,6 @@
 
 namespace wheel_ffb {
 
-inline constexpr uint32_t kPedalAccelerate = 1u;
-inline constexpr uint32_t kPedalBrake = 2u;
-
 bool IsWheelDevice(uint16_t vendor, uint16_t product);
 uint32_t PedalButtons(uint32_t port);
 void NotifyControllersChanged();

--- a/runtime/include/wheel_ffb.h
+++ b/runtime/include/wheel_ffb.h
@@ -4,7 +4,11 @@
 
 namespace wheel_ffb {
 
+inline constexpr uint32_t kPedalAccelerate = 1u;
+inline constexpr uint32_t kPedalBrake = 2u;
+
 bool IsWheelDevice(uint16_t vendor, uint16_t product);
+uint32_t PedalButtons(uint32_t port);
 void NotifyControllersChanged();
 void Tick();
 bool OnMotorCommand(int32_t chan, uint32_t command);

--- a/runtime/include/wheel_ffb.h
+++ b/runtime/include/wheel_ffb.h
@@ -4,6 +4,7 @@
 
 namespace wheel_ffb {
 
+bool IsWheelDevice(uint16_t vendor, uint16_t product);
 void NotifyControllersChanged();
 void Tick();
 bool OnMotorCommand(int32_t chan, uint32_t command);
@@ -13,5 +14,7 @@ float SteeringPosition();
 void ApplyStrength(int percent);
 void ApplySpring(int percent);
 void ApplyVibration(int percent);
+void ApplySteeringSensitivity(int percent);
+int32_t ShapeSteering(uint32_t port, int32_t stickX);
 
 } // namespace wheel_ffb

--- a/runtime/include/wheel_ffb.h
+++ b/runtime/include/wheel_ffb.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+namespace wheel_ffb {
+
+void NotifyControllersChanged();
+void Tick();
+bool OnMotorCommand(int32_t chan, uint32_t command);
+bool IsWheelPort(uint32_t port);
+const char* StatusText();
+float SteeringPosition();
+void ApplyStrength(int percent);
+void ApplySpring(int percent);
+void ApplyVibration(int percent);
+
+} // namespace wheel_ffb

--- a/runtime/src/controller_mapping_wizard.cpp
+++ b/runtime/src/controller_mapping_wizard.cpp
@@ -1,6 +1,7 @@
 #include "controller_mapping_wizard.h"
 #include "runtime_config.h"
 #include "runtime_log.h"
+#include "wheel_ffb.h"
 
 #include <imgui.h>
 #include <SDL3/SDL_gamepad.h>
@@ -69,11 +70,18 @@ struct WizardState {
     size_t stepIndex = 0;
     std::array<std::optional<std::string>, kSteps.size()> bindings{};
     std::vector<int16_t> axisBaseline;
+    bool baselinePending = true;
     Clock::time_point acceptAfter{};
     std::string status;
 };
 
 WizardState g_wizard;
+
+std::vector<std::string> g_userMappedGuids;
+
+constexpr const char* kWheelMappingFields =
+    "a:a1~,b:a2~,x:b0,y:b3,rightshoulder:b2,lefttrigger:b5,righttrigger:b4,start:b9,back:b8,"
+    "dpup:h0.1,dpright:h0.2,dpdown:h0.4,dpleft:h0.8,leftx:a0,platform:Windows,";
 
 std::filesystem::path MappingDbPath() {
     return RuntimeConfigFile::ApplicationDataDirectory() / "gamecontrollerdb.txt";
@@ -102,6 +110,7 @@ void AdvanceStep(std::optional<std::string> value) {
     g_wizard.bindings[g_wizard.stepIndex] = std::move(value);
     ++g_wizard.stepIndex;
     g_wizard.acceptAfter = Clock::now() + kCaptureDebounce;
+    g_wizard.baselinePending = true;
     SnapshotAxes();
 }
 
@@ -134,6 +143,7 @@ void StartWizard(SDL_JoystickID instance) {
     const char* name = SDL_GetJoystickNameForID(instance);
     g_wizard.deviceName = name != nullptr ? name : "Controller";
     g_wizard.acceptAfter = Clock::now() + kCaptureDebounce;
+    g_wizard.baselinePending = true;
     SnapshotAxes();
 }
 
@@ -328,6 +338,10 @@ void LoadPersistedMappings() {
         if (trimmed.empty() || trimmed[0] == '#') {
             continue;
         }
+        const size_t comma = trimmed.find(',');
+        if (comma != std::string::npos) {
+            g_userMappedGuids.push_back(trimmed.substr(0, comma));
+        }
         if (SDL_AddGamepadMapping(trimmed.c_str()) >= 0) {
             ++added;
         } else {
@@ -341,7 +355,40 @@ void LoadPersistedMappings() {
     }
 }
 
+void ApplyBuiltinWheelMappings() {
+    int count = 0;
+    SDL_JoystickID* ids = SDL_GetJoysticks(&count);
+    if (ids == nullptr) {
+        return;
+    }
+    for (int i = 0; i < count; ++i) {
+        if (!wheel_ffb::IsWheelDevice(SDL_GetJoystickVendorForID(ids[i]),
+                                      SDL_GetJoystickProductForID(ids[i]))) {
+            continue;
+        }
+        const std::string guid = GuidString(ids[i]);
+        if (std::find(g_userMappedGuids.begin(), g_userMappedGuids.end(), guid) !=
+            g_userMappedGuids.end()) {
+            continue;
+        }
+        const char* rawName = SDL_GetJoystickNameForID(ids[i]);
+        std::string name = rawName != nullptr ? rawName : "Racing Wheel";
+        std::replace(name.begin(), name.end(), ',', ' ');
+        const std::string mapping = guid + "," + name + "," + kWheelMappingFields;
+        if (SDL_AddGamepadMapping(mapping.c_str()) < 0) {
+            RT_LOG(RT_TAG_CONFIG) << "wheel profile: rejected for " << name << ": " << SDL_GetError()
+                                  << std::endl;
+            continue;
+        }
+        RT_LOG(RT_TAG_CONFIG) << "wheel profile: applied built-in layout for " << name << std::endl;
+    }
+    SDL_free(ids);
+}
+
 void HandleSdlEvent(const SDL_Event& event) {
+    if (event.type == SDL_EVENT_JOYSTICK_ADDED) {
+        ApplyBuiltinWheelMappings();
+    }
     if (!g_wizard.active) {
         return;
     }
@@ -357,6 +404,10 @@ void HandleSdlEvent(const SDL_Event& event) {
         return;
     }
     if (Clock::now() < g_wizard.acceptAfter) {
+        return;
+    }
+    if (g_wizard.baselinePending) {
+        g_wizard.baselinePending = false;
         SnapshotAxes();
         return;
     }

--- a/runtime/src/controller_mapping_wizard.cpp
+++ b/runtime/src/controller_mapping_wizard.cpp
@@ -80,7 +80,7 @@ WizardState g_wizard;
 std::vector<std::string> g_userMappedGuids;
 
 constexpr const char* kWheelMappingFields =
-    "a:a2~,b:a1~,x:b0,y:b3,rightshoulder:b2,lefttrigger:b5,righttrigger:b4,start:b9,back:b8,"
+    "a:b0,b:b2,x:b1,y:b3,rightshoulder:b7,lefttrigger:b5,righttrigger:b4,start:b9,back:b8,"
     "dpup:h0.1,dpright:h0.2,dpdown:h0.4,dpleft:h0.8,leftx:a0,platform:Windows,";
 
 std::filesystem::path MappingDbPath() {

--- a/runtime/src/controller_mapping_wizard.cpp
+++ b/runtime/src/controller_mapping_wizard.cpp
@@ -202,6 +202,7 @@ void FinishWizard() {
         RT_LOG(RT_TAG_CONFIG) << "controller wizard: " << g_wizard.status << std::endl;
         return;
     }
+    g_userMappedGuids.push_back(guid);
     RT_LOG(RT_TAG_CONFIG) << "controller wizard: applied mapping " << mapping << std::endl;
     StopWizard();
 }
@@ -373,7 +374,9 @@ void ApplyBuiltinWheelMappings() {
         }
         const std::string guid = GuidString(ids[i]);
         if (std::find(g_userMappedGuids.begin(), g_userMappedGuids.end(), guid) !=
-            g_userMappedGuids.end()) {
+                g_userMappedGuids.end() ||
+            std::find(g_builtinMappedGuids.begin(), g_builtinMappedGuids.end(), guid) !=
+                g_builtinMappedGuids.end()) {
             continue;
         }
         const char* rawName = SDL_GetJoystickNameForID(ids[i]);

--- a/runtime/src/controller_mapping_wizard.cpp
+++ b/runtime/src/controller_mapping_wizard.cpp
@@ -23,13 +23,13 @@ namespace {
 using Clock = std::chrono::steady_clock;
 
 constexpr int16_t kStickThreshold = 16000;
-constexpr int16_t kTriggerThreshold = 10000;
+constexpr int16_t kPressThreshold = 10000;
+constexpr int16_t kExtremeRestZone = 24000;
 constexpr auto kCaptureDebounce = std::chrono::milliseconds(350);
 
 enum class StepKind {
-    Button,  // button or single-direction hat press
-    Trigger, // button press or axis pull
-    Stick,   // axis motion in the prompted direction
+    Press,
+    Stick,
 };
 
 struct Step {
@@ -42,18 +42,18 @@ struct Step {
 // right GC controls through pad.cpp's "standard" defaults (Z lives on
 // rightshoulder, L/R on the trigger axes).
 constexpr std::array<Step, 16> kSteps = {{
-    {"a", "Press the button for A (accelerate / select)", StepKind::Button},
-    {"b", "Press the button for B (brake / back)", StepKind::Button},
-    {"x", "Press the button for X", StepKind::Button},
-    {"y", "Press the button for Y", StepKind::Button},
-    {"start", "Press the button for pause (Start)", StepKind::Button},
-    {"rightshoulder", "Press the button for rear view (Z)", StepKind::Button},
-    {"lefttrigger", "Press or pull the control for using items (L)", StepKind::Trigger},
-    {"righttrigger", "Press or pull the control for hop / drift (R)", StepKind::Trigger},
-    {"dpup", "Press D-pad Up", StepKind::Button},
-    {"dpdown", "Press D-pad Down", StepKind::Button},
-    {"dpleft", "Press D-pad Left", StepKind::Button},
-    {"dpright", "Press D-pad Right", StepKind::Button},
+    {"a", "Press the button or pedal for A (accelerate / select)", StepKind::Press},
+    {"b", "Press the button or pedal for B (brake / back)", StepKind::Press},
+    {"x", "Press the button for X", StepKind::Press},
+    {"y", "Press the button for Y", StepKind::Press},
+    {"start", "Press the button for pause (Start)", StepKind::Press},
+    {"rightshoulder", "Press the button for rear view (Z)", StepKind::Press},
+    {"lefttrigger", "Press or pull the control for using items (L)", StepKind::Press},
+    {"righttrigger", "Press or pull the control for hop / drift (R)", StepKind::Press},
+    {"dpup", "Press D-pad Up", StepKind::Press},
+    {"dpdown", "Press D-pad Down", StepKind::Press},
+    {"dpleft", "Press D-pad Left", StepKind::Press},
+    {"dpright", "Press D-pad Right", StepKind::Press},
     {"leftx", "Move the Control Stick LEFT", StepKind::Stick},
     {"lefty", "Move the Control Stick UP", StepKind::Stick},
     {"rightx", "Move the C-Stick LEFT (or Skip)", StepKind::Stick},
@@ -229,8 +229,7 @@ std::vector<SetupCandidate> CollectCandidates() {
         }
         const std::string mappingStr = mapping;
         SDL_free(mapping);
-        const bool hasStick = mappingStr.find("leftx:") != std::string::npos &&
-                              mappingStr.find("lefty:") != std::string::npos;
+        const bool hasStick = mappingStr.find("leftx:") != std::string::npos;
         SDL_Joystick* joystick = SDL_GetGamepadJoystick(gamepad);
         if (!hasStick && joystick != nullptr && SDL_GetNumJoystickAxes(joystick) >= 2) {
             candidates.push_back({id, name, true});
@@ -274,33 +273,42 @@ void HandleHatMotion(const SDL_JoyHatEvent& event) {
     AdvanceStep(value);
 }
 
+bool AxisBindingConflicts(const std::string& value, const std::string& axis) {
+    if (value[0] == '+' || value[0] == '-') {
+        return BindingUsed(value) || BindingUsed(axis) || BindingUsed(axis + "~");
+    }
+    return BindingUsed(axis) || BindingUsed(axis + "~") || BindingUsed("+" + axis) ||
+           BindingUsed("-" + axis);
+}
+
 void HandleAxisMotion(const SDL_JoyAxisEvent& event) {
     const Step& step = kSteps[g_wizard.stepIndex];
-    if (step.kind == StepKind::Button) {
-        return;
-    }
     if (event.axis >= g_wizard.axisBaseline.size()) {
         return;
     }
-    const int32_t delta =
-        static_cast<int32_t>(event.value) - static_cast<int32_t>(g_wizard.axisBaseline[event.axis]);
-    const int16_t threshold = step.kind == StepKind::Stick ? kStickThreshold : kTriggerThreshold;
+    const int16_t baseline = g_wizard.axisBaseline[event.axis];
+    const int32_t delta = static_cast<int32_t>(event.value) - static_cast<int32_t>(baseline);
+    const int16_t threshold = step.kind == StepKind::Stick ? kStickThreshold : kPressThreshold;
     if (std::abs(delta) < threshold) {
         return;
     }
-    // Stick prompts ask for LEFT/UP, which SDL expects to be negative; triggers
-    // are expected to increase when pulled. A wrong-way delta means the raw
-    // axis is inverted, which the mapping expresses with a '~' suffix.
-    const bool expectNegative = step.kind == StepKind::Stick;
-    const bool inverted = expectNegative ? delta > 0 : delta < 0;
-    std::string value = "a" + std::to_string(event.axis);
-    // Reject reusing an axis already bound (with or without inversion).
-    if (BindingUsed(value) || BindingUsed(value + "~")) {
-        g_wizard.status = "That axis is already bound";
+    const bool restsAtExtreme = std::abs(static_cast<int32_t>(baseline)) > kExtremeRestZone;
+    if (step.kind == StepKind::Stick && restsAtExtreme) {
+        g_wizard.status = "That control rests at an extreme, like a pedal; use the wheel or a stick";
         return;
     }
-    if (inverted) {
-        value += "~";
+    const std::string axis = "a" + std::to_string(event.axis);
+    std::string value;
+    if (step.kind == StepKind::Press && !restsAtExtreme) {
+        value = (delta < 0 ? "-" : "+") + axis;
+    } else if (step.kind == StepKind::Stick ? delta > 0 : delta < 0) {
+        value = axis + "~";
+    } else {
+        value = axis;
+    }
+    if (AxisBindingConflicts(value, axis)) {
+        g_wizard.status = "That axis is already bound";
+        return;
     }
     g_wizard.status.clear();
     AdvanceStep(value);
@@ -345,7 +353,11 @@ void HandleSdlEvent(const SDL_Event& event) {
         StopWizard();
         return;
     }
-    if (g_wizard.stepIndex >= kSteps.size() || Clock::now() < g_wizard.acceptAfter) {
+    if (g_wizard.stepIndex >= kSteps.size()) {
+        return;
+    }
+    if (Clock::now() < g_wizard.acceptAfter) {
+        SnapshotAxes();
         return;
     }
     switch (event.type) {

--- a/runtime/src/controller_mapping_wizard.cpp
+++ b/runtime/src/controller_mapping_wizard.cpp
@@ -78,6 +78,7 @@ struct WizardState {
 WizardState g_wizard;
 
 std::vector<std::string> g_userMappedGuids;
+std::vector<std::string> g_builtinMappedGuids;
 
 constexpr const char* kWheelMappingFields =
     "a:b0,b:b2,x:b1,y:b3,rightshoulder:b7,lefttrigger:b5,righttrigger:b4,start:b9,back:b8,"
@@ -229,6 +230,11 @@ std::vector<SetupCandidate> CollectCandidates() {
             candidates.push_back({id, name, false});
             continue;
         }
+        if (std::find(g_builtinMappedGuids.begin(), g_builtinMappedGuids.end(), GuidString(id)) !=
+            g_builtinMappedGuids.end()) {
+            candidates.push_back({id, name, false});
+            continue;
+        }
         SDL_Gamepad* gamepad = SDL_GetGamepadFromID(id);
         if (gamepad == nullptr) {
             continue;
@@ -362,8 +368,7 @@ void ApplyBuiltinWheelMappings() {
         return;
     }
     for (int i = 0; i < count; ++i) {
-        if (!wheel_ffb::IsWheelDevice(SDL_GetJoystickVendorForID(ids[i]),
-                                      SDL_GetJoystickProductForID(ids[i]))) {
+        if (!wheel_ffb::HasBuiltinLayout(ids[i])) {
             continue;
         }
         const std::string guid = GuidString(ids[i]);
@@ -380,6 +385,7 @@ void ApplyBuiltinWheelMappings() {
                                   << std::endl;
             continue;
         }
+        g_builtinMappedGuids.push_back(guid);
         RT_LOG(RT_TAG_CONFIG) << "wheel profile: applied built-in layout for " << name << std::endl;
     }
     SDL_free(ids);

--- a/runtime/src/controller_mapping_wizard.cpp
+++ b/runtime/src/controller_mapping_wizard.cpp
@@ -80,7 +80,7 @@ WizardState g_wizard;
 std::vector<std::string> g_userMappedGuids;
 
 constexpr const char* kWheelMappingFields =
-    "a:a1~,b:a2~,x:b0,y:b3,rightshoulder:b2,lefttrigger:b5,righttrigger:b4,start:b9,back:b8,"
+    "a:a2~,b:a1~,x:b0,y:b3,rightshoulder:b2,lefttrigger:b5,righttrigger:b4,start:b9,back:b8,"
     "dpup:h0.1,dpright:h0.2,dpdown:h0.4,dpleft:h0.8,leftx:a0,platform:Windows,";
 
 std::filesystem::path MappingDbPath() {

--- a/runtime/src/hle/input/pad.cpp
+++ b/runtime/src/hle/input/pad.cpp
@@ -1,6 +1,7 @@
 #include "hle_stubs.h"
 #include "memory.h"
 #include "hle/controller_status_contract.h"
+#include "controller_mapping_wizard.h"
 #include "wheel_ffb.h"
 
 #include <algorithm>
@@ -47,9 +48,12 @@ extern "C" uint32_t PAD__Read_HLE(uint32_t statusPtr)
     PADStatus statuses[PAD_CHANMAX]{};
     uint32_t rumbleMask = PADRead(statuses);
 
-    for (uint32_t i = 0; i < PAD_CHANMAX; ++i) {
-        statuses[i].stickX = static_cast<int8_t>(wheel_ffb::ShapeSteering(i, statuses[i].stickX));
-        statuses[i].button |= static_cast<uint16_t>(wheel_ffb::PedalButtons(i));
+    if (!controller_mapping_wizard::IsActive()) {
+        for (uint32_t i = 0; i < PAD_CHANMAX; ++i) {
+            statuses[i].stickX =
+                static_cast<int8_t>(wheel_ffb::ShapeSteering(i, statuses[i].stickX));
+            statuses[i].button |= static_cast<uint16_t>(wheel_ffb::PedalButtons(i));
+        }
     }
 
     try {

--- a/runtime/src/hle/input/pad.cpp
+++ b/runtime/src/hle/input/pad.cpp
@@ -1,6 +1,7 @@
 #include "hle_stubs.h"
 #include "memory.h"
 #include "hle/controller_status_contract.h"
+#include "wheel_ffb.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -73,6 +74,9 @@ PPC_NATIVE_OVERRIDE(801AF1E4, PAD__Recalibrate_HLE, uint32_t, (uint32_t mask), (
 
 extern "C" void PAD__ControlMotor_HLE(int32_t chan, uint32_t command)
 {
+    if (wheel_ffb::OnMotorCommand(chan, command)) {
+        return;
+    }
     PADControlMotor(chan, command);
 }
 PPC_NATIVE_OVERRIDE_VOID(801AF908, PAD__ControlMotor_HLE, (int32_t chan, uint32_t command), (chan, command));

--- a/runtime/src/hle/input/pad.cpp
+++ b/runtime/src/hle/input/pad.cpp
@@ -50,6 +50,13 @@ extern "C" uint32_t PAD__Read_HLE(uint32_t statusPtr)
     try {
         for (uint32_t i = 0; i < PAD_CHANMAX; ++i) {
             statuses[i].stickX = static_cast<int8_t>(wheel_ffb::ShapeSteering(i, statuses[i].stickX));
+            const uint32_t pedals = wheel_ffb::PedalButtons(i);
+            if ((pedals & wheel_ffb::kPedalAccelerate) != 0) {
+                statuses[i].button |= PAD_BUTTON_A;
+            }
+            if ((pedals & wheel_ffb::kPedalBrake) != 0) {
+                statuses[i].button |= PAD_BUTTON_B;
+            }
             WritePadStatus(statusPtr + static_cast<uint32_t>(i * PadStatusContract::kGuestStatusSize),
                            statuses[i]);
         }

--- a/runtime/src/hle/input/pad.cpp
+++ b/runtime/src/hle/input/pad.cpp
@@ -49,6 +49,7 @@ extern "C" uint32_t PAD__Read_HLE(uint32_t statusPtr)
 
     try {
         for (uint32_t i = 0; i < PAD_CHANMAX; ++i) {
+            statuses[i].stickX = static_cast<int8_t>(wheel_ffb::ShapeSteering(i, statuses[i].stickX));
             WritePadStatus(statusPtr + static_cast<uint32_t>(i * PadStatusContract::kGuestStatusSize),
                            statuses[i]);
         }

--- a/runtime/src/hle/input/pad.cpp
+++ b/runtime/src/hle/input/pad.cpp
@@ -47,16 +47,13 @@ extern "C" uint32_t PAD__Read_HLE(uint32_t statusPtr)
     PADStatus statuses[PAD_CHANMAX]{};
     uint32_t rumbleMask = PADRead(statuses);
 
+    for (uint32_t i = 0; i < PAD_CHANMAX; ++i) {
+        statuses[i].stickX = static_cast<int8_t>(wheel_ffb::ShapeSteering(i, statuses[i].stickX));
+        statuses[i].button |= static_cast<uint16_t>(wheel_ffb::PedalButtons(i));
+    }
+
     try {
         for (uint32_t i = 0; i < PAD_CHANMAX; ++i) {
-            statuses[i].stickX = static_cast<int8_t>(wheel_ffb::ShapeSteering(i, statuses[i].stickX));
-            const uint32_t pedals = wheel_ffb::PedalButtons(i);
-            if ((pedals & wheel_ffb::kPedalAccelerate) != 0) {
-                statuses[i].button |= PAD_BUTTON_A;
-            }
-            if ((pedals & wheel_ffb::kPedalBrake) != 0) {
-                statuses[i].button |= PAD_BUTTON_B;
-            }
             WritePadStatus(statusPtr + static_cast<uint32_t>(i * PadStatusContract::kGuestStatusSize),
                            statuses[i]);
         }

--- a/runtime/src/hle/vi.cpp
+++ b/runtime/src/hle/vi.cpp
@@ -5,6 +5,7 @@
 #include "ppc_runtime.h"
 #include "aurora_events.h"
 #include "settings_overlay.h"
+#include "wheel_ffb.h"
 #include "fiber_manager.h"
 #include "runtime_log.h"
 
@@ -586,6 +587,7 @@ void VI_HLE_PresentFrame(bool presentedXfb, bool paceToRetrace) {
         s_lastPacedRetraceCount = g_vi.retraceCount;
     }
     settings_overlay::AdvancePresentedFrame();
+    wheel_ffb::Tick();
     g_auroraFrameActive.store(false, std::memory_order_release);
     g_auroraFrameHadWork.store(false, std::memory_order_release);
     if (presentedXfb) {

--- a/runtime/src/settings_overlay.cpp
+++ b/runtime/src/settings_overlay.cpp
@@ -511,15 +511,16 @@ void DrawControllerSettings() {
                 if (!ImGui::BeginCombo(label, current.c_str())) {
                     return;
                 }
-                for (int candidate = -1; candidate < 8; ++candidate) {
-                    const std::string name = candidate < 0 ? "Detected automatically"
-                                                           : "Axis " + std::to_string(candidate);
-                    if (ImGui::Selectable(name.c_str(), candidate == axis)) {
-                        axis = candidate;
+                for (int candidate = 0; candidate < 8; ++candidate) {
+                    const int value = candidate == 0 ? -1 : candidate;
+                    const std::string name =
+                        candidate == 0 ? "Detected automatically" : "Axis " + std::to_string(value);
+                    if (ImGui::Selectable(name.c_str(), value == axis)) {
+                        axis = value;
                         if (accelerator) {
-                            RuntimeConfigFile::SetAcceleratorAxis(candidate);
+                            RuntimeConfigFile::SetAcceleratorAxis(value);
                         } else {
-                            RuntimeConfigFile::SetBrakeAxis(candidate);
+                            RuntimeConfigFile::SetBrakeAxis(value);
                         }
                     }
                 }

--- a/runtime/src/settings_overlay.cpp
+++ b/runtime/src/settings_overlay.cpp
@@ -5,6 +5,7 @@
 #include "music_attenuation.h"
 #include "runtime_config.h"
 #include "runtime_log.h"
+#include "wheel_ffb.h"
 
 #include <imgui.h>
 #include <SDL3/SDL_events.h>
@@ -99,6 +100,9 @@ bool g_skipUnreadyPipelines = RuntimeConfigFile::SkipUnreadyPipelines(true);
 bool g_disableCopyFilter = RuntimeConfigFile::DisableCopyFilter(true);
 bool g_showFps = RuntimeConfigFile::ShowFps(true);
 uint32_t g_disabledPostProcessingPaths = RuntimeConfigFile::DisabledPostProcessingPaths(0);
+int g_ffbStrength = RuntimeConfigFile::FfbStrength();
+int g_ffbSpring = RuntimeConfigFile::FfbSpring();
+int g_ffbVibration = RuntimeConfigFile::FfbVibration();
 std::array<int32_t, PAD_MAX_CONTROLLERS> g_configuredControllerIndices = [] {
     std::array<int32_t, PAD_MAX_CONTROLLERS> indices{};
     indices.fill(std::numeric_limits<int32_t>::min());
@@ -326,6 +330,7 @@ void DrawControllerSettings() {
     if (ImGui::MenuItem("Unassign controller")) {
         PADClearPort(selectedGamePort);
         g_configuredControllerIndices.fill(std::numeric_limits<int32_t>::min());
+        wheel_ffb::NotifyControllersChanged();
     }
     ImGui::Separator();
     controller_mapping_wizard::DrawSetupList();
@@ -343,6 +348,7 @@ void DrawControllerSettings() {
                 PADSetPortForIndex(index, selectedGamePort);
                 g_configuredControllerIndices.fill(std::numeric_limits<int32_t>::min());
                 ApplyConfiguredMappings();
+                wheel_ffb::NotifyControllersChanged();
             }
             ImGui::PopID();
         }
@@ -449,6 +455,45 @@ void DrawControllerSettings() {
         }
         if (ImGui::IsItemDeactivatedAfterEdit()) {
             PADSerializeMappings();
+        }
+    }
+
+    if (wheel_ffb::IsWheelPort(selectedGamePort)) {
+        ImGui::SeparatorText("Force feedback");
+        bool ffbEnabled = RuntimeConfigFile::FfbEnabled();
+        if (ImGui::Checkbox("Enabled##ffb", &ffbEnabled)) {
+            RuntimeConfigFile::SetFfbEnabled(ffbEnabled);
+            wheel_ffb::NotifyControllersChanged();
+        }
+        ImGui::TextDisabled("%s", wheel_ffb::StatusText());
+        if (ffbEnabled) {
+            ImGui::SetNextItemWidth(190.0f);
+            if (ImGui::SliderInt("Strength", &g_ffbStrength, 0, 100, "%d%%",
+                                 ImGuiSliderFlags_AlwaysClamp)) {
+                wheel_ffb::ApplyStrength(g_ffbStrength);
+            }
+            if (ImGui::IsItemDeactivatedAfterEdit()) {
+                RuntimeConfigFile::SetFfbStrength(g_ffbStrength);
+            }
+            ImGui::SetNextItemWidth(190.0f);
+            if (ImGui::SliderInt("Centering spring", &g_ffbSpring, 0, 100, "%d%%",
+                                 ImGuiSliderFlags_AlwaysClamp)) {
+                wheel_ffb::ApplySpring(g_ffbSpring);
+            }
+            if (ImGui::IsItemDeactivatedAfterEdit()) {
+                RuntimeConfigFile::SetFfbSpring(g_ffbSpring);
+            }
+            ImGui::SetNextItemWidth(190.0f);
+            if (ImGui::SliderInt("Vibration", &g_ffbVibration, 0, 100, "%d%%",
+                                 ImGuiSliderFlags_AlwaysClamp)) {
+                wheel_ffb::ApplyVibration(g_ffbVibration);
+            }
+            if (ImGui::IsItemDeactivatedAfterEdit()) {
+                RuntimeConfigFile::SetFfbVibration(g_ffbVibration);
+            }
+            ImGui::ProgressBar((wheel_ffb::SteeringPosition() + 1.0f) * 0.5f,
+                               ImVec2(190.0f, 0.0f), "Steering");
+            ImGui::TextDisabled("Set the wheel's rotation range in G HUB (270-360 works well)");
         }
     }
 
@@ -914,6 +959,7 @@ void HandleEvents(const AuroraEvent* events) noexcept {
     for (const AuroraEvent* ev = events; ev->type != AURORA_NONE; ++ev) {
         if (ev->type == AURORA_CONTROLLER_ADDED || ev->type == AURORA_CONTROLLER_REMOVED) {
             g_configuredControllerIndices.fill(std::numeric_limits<int32_t>::min());
+            wheel_ffb::NotifyControllersChanged();
         }
         if (ev->type != AURORA_SDL_EVENT) {
             continue;

--- a/runtime/src/settings_overlay.cpp
+++ b/runtime/src/settings_overlay.cpp
@@ -468,7 +468,7 @@ void DrawControllerSettings() {
         }
         ImGui::TextDisabled("%s", wheel_ffb::StatusText());
         ImGui::SetNextItemWidth(190.0f);
-        if (ImGui::SliderInt("Steering sensitivity", &g_steeringSensitivity, 100, 400, "%d%%",
+        if (ImGui::SliderInt("Steering sensitivity", &g_steeringSensitivity, 100, 900, "%d%%",
                              ImGuiSliderFlags_AlwaysClamp)) {
             wheel_ffb::ApplySteeringSensitivity(g_steeringSensitivity);
         }

--- a/runtime/src/settings_overlay.cpp
+++ b/runtime/src/settings_overlay.cpp
@@ -104,6 +104,8 @@ int g_ffbStrength = RuntimeConfigFile::FfbStrength();
 int g_ffbSpring = RuntimeConfigFile::FfbSpring();
 int g_ffbVibration = RuntimeConfigFile::FfbVibration();
 int g_steeringSensitivity = RuntimeConfigFile::SteeringSensitivity();
+int g_acceleratorAxis = RuntimeConfigFile::AcceleratorAxis();
+int g_brakeAxis = RuntimeConfigFile::BrakeAxis();
 std::array<int32_t, PAD_MAX_CONTROLLERS> g_configuredControllerIndices = [] {
     std::array<int32_t, PAD_MAX_CONTROLLERS> indices{};
     indices.fill(std::numeric_limits<int32_t>::min());
@@ -502,6 +504,29 @@ void DrawControllerSettings() {
             }
             ImGui::ProgressBar((wheel_ffb::SteeringPosition() + 1.0f) * 0.5f,
                                ImVec2(190.0f, 0.0f), "Steering");
+            const auto pedalCombo = [](const char* label, int& axis, bool accelerator) {
+                ImGui::SetNextItemWidth(190.0f);
+                const std::string current =
+                    axis < 0 ? "Detected automatically" : "Axis " + std::to_string(axis);
+                if (!ImGui::BeginCombo(label, current.c_str())) {
+                    return;
+                }
+                for (int candidate = -1; candidate < 8; ++candidate) {
+                    const std::string name = candidate < 0 ? "Detected automatically"
+                                                           : "Axis " + std::to_string(candidate);
+                    if (ImGui::Selectable(name.c_str(), candidate == axis)) {
+                        axis = candidate;
+                        if (accelerator) {
+                            RuntimeConfigFile::SetAcceleratorAxis(candidate);
+                        } else {
+                            RuntimeConfigFile::SetBrakeAxis(candidate);
+                        }
+                    }
+                }
+                ImGui::EndCombo();
+            };
+            pedalCombo("Accelerator", g_acceleratorAxis, true);
+            pedalCombo("Brake", g_brakeAxis, false);
             ImGui::TextDisabled("Set the wheel's rotation range in G HUB (270-360 works well)");
         }
     }

--- a/runtime/src/settings_overlay.cpp
+++ b/runtime/src/settings_overlay.cpp
@@ -103,6 +103,7 @@ uint32_t g_disabledPostProcessingPaths = RuntimeConfigFile::DisabledPostProcessi
 int g_ffbStrength = RuntimeConfigFile::FfbStrength();
 int g_ffbSpring = RuntimeConfigFile::FfbSpring();
 int g_ffbVibration = RuntimeConfigFile::FfbVibration();
+int g_steeringSensitivity = RuntimeConfigFile::SteeringSensitivity();
 std::array<int32_t, PAD_MAX_CONTROLLERS> g_configuredControllerIndices = [] {
     std::array<int32_t, PAD_MAX_CONTROLLERS> indices{};
     indices.fill(std::numeric_limits<int32_t>::min());
@@ -466,6 +467,14 @@ void DrawControllerSettings() {
             wheel_ffb::NotifyControllersChanged();
         }
         ImGui::TextDisabled("%s", wheel_ffb::StatusText());
+        ImGui::SetNextItemWidth(190.0f);
+        if (ImGui::SliderInt("Steering sensitivity", &g_steeringSensitivity, 100, 400, "%d%%",
+                             ImGuiSliderFlags_AlwaysClamp)) {
+            wheel_ffb::ApplySteeringSensitivity(g_steeringSensitivity);
+        }
+        if (ImGui::IsItemDeactivatedAfterEdit()) {
+            RuntimeConfigFile::SetSteeringSensitivity(g_steeringSensitivity);
+        }
         if (ffbEnabled) {
             ImGui::SetNextItemWidth(190.0f);
             if (ImGui::SliderInt("Strength", &g_ffbStrength, 0, 100, "%d%%",
@@ -931,6 +940,7 @@ void PersistDisplayModeIfChanged() {
 
 void InitializeRuntimeSettings() noexcept {
     controller_mapping_wizard::LoadPersistedMappings();
+    controller_mapping_wizard::ApplyBuiltinWheelMappings();
     ApplyConfiguredMappings();
     AudioBackend::Instance().SetMasterVolume(static_cast<float>(g_audioVolumePercent) / 100.0f);
     AudioBackend::Instance().SetMuted(g_audioMuted);

--- a/runtime/src/settings_overlay.cpp
+++ b/runtime/src/settings_overlay.cpp
@@ -413,6 +413,45 @@ void DrawControllerSettings() {
         mappings = PADGetButtonMappings(port, &mappingCount);
     }
 
+    ImGui::SeparatorText("Analog");
+    if (PADDeadZones* zones = PADGetDeadZones(static_cast<uint32_t>(g_controllerPort))) {
+        int stickDeadzone = zones->stickDeadZone;
+        ImGui::SetNextItemWidth(190.0f);
+        if (ImGui::SliderInt("Stick dead zone", &stickDeadzone, 0, 16000, "%d",
+                             ImGuiSliderFlags_AlwaysClamp)) {
+            zones->stickDeadZone = static_cast<uint16_t>(stickDeadzone);
+            zones->substickDeadZone = static_cast<uint16_t>(stickDeadzone);
+        }
+        if (ImGui::IsItemDeactivatedAfterEdit()) {
+            PADSerializeMappings();
+        }
+        int triggerZone = zones->leftTriggerActivationZone;
+        ImGui::SetNextItemWidth(190.0f);
+        if (ImGui::SliderInt("L/R press point", &triggerZone, 1000, 32000, "%d",
+                             ImGuiSliderFlags_AlwaysClamp)) {
+            zones->leftTriggerActivationZone = static_cast<uint16_t>(triggerZone);
+            zones->rightTriggerActivationZone = static_cast<uint16_t>(triggerZone);
+        }
+        if (ImGui::IsItemDeactivatedAfterEdit()) {
+            PADSerializeMappings();
+        }
+    }
+    if (PADSupportsRumbleIntensity(static_cast<uint32_t>(g_controllerPort))) {
+        uint16_t low = 0;
+        uint16_t high = 0;
+        PADGetRumbleIntensity(static_cast<uint32_t>(g_controllerPort), &low, &high);
+        int rumblePercent = (static_cast<int>(low) * 100 + INT16_MAX / 2) / INT16_MAX;
+        ImGui::SetNextItemWidth(190.0f);
+        if (ImGui::SliderInt("Rumble strength", &rumblePercent, 0, 100, "%d%%",
+                             ImGuiSliderFlags_AlwaysClamp)) {
+            const auto intensity = static_cast<uint16_t>((rumblePercent * INT16_MAX + 50) / 100);
+            PADSetRumbleIntensity(static_cast<uint32_t>(g_controllerPort), intensity, intensity);
+        }
+        if (ImGui::IsItemDeactivatedAfterEdit()) {
+            PADSerializeMappings();
+        }
+    }
+
     ImGui::SeparatorText("Button mapping");
     for (size_t i = 0; i < kControllerButtons.size(); ++i) {
         auto mappingIt = std::find_if(mappings, mappings + mappingCount, [&](const PADButtonMapping& mapping) {

--- a/runtime/src/wheel_ffb.cpp
+++ b/runtime/src/wheel_ffb.cpp
@@ -49,7 +49,6 @@ struct Session {
     uint32_t features = 0;
     SDL_HapticEffectID springId = -1;
     SDL_HapticEffectID sineId = -1;
-    SDL_HapticEffect sine{};
     bool sineRunning = false;
     int16_t sineMagnitude = 0;
     Clock::time_point sineRunStamp{};
@@ -83,6 +82,17 @@ SDL_Joystick* JoystickForPort(uint32_t port) {
     }
     SDL_Gamepad* gamepad = PADGetSDLGamepadForIndex(static_cast<uint32_t>(index));
     return gamepad != nullptr ? SDL_GetGamepadJoystick(gamepad) : nullptr;
+}
+
+SDL_Joystick* WheelForPort(uint32_t port) {
+    SDL_Joystick* joystick = JoystickForPort(port);
+    if (joystick == nullptr) {
+        return nullptr;
+    }
+    if (!IsKnownWheel(joystick) && !RuntimeConfigFile::FfbForceWheel()) {
+        return nullptr;
+    }
+    return joystick;
 }
 
 bool NamesRelated(const char* joystickName, const char* hapticName) {
@@ -219,8 +229,8 @@ void OpenSession(uint32_t port, SDL_Joystick* joystick) {
         SDL_SetHapticAutocenter(haptic, g_spring);
     }
     if ((g_session.features & SDL_HAPTIC_SINE) != 0) {
-        g_session.sine = SineEffect();
-        g_session.sineId = SDL_CreateHapticEffect(haptic, &g_session.sine);
+        SDL_HapticEffect effect = SineEffect();
+        g_session.sineId = SDL_CreateHapticEffect(haptic, &effect);
     }
     if (springRunning) {
         g_status = g_session.sineId >= 0 ? "Active" : "Active, no vibration support";
@@ -240,9 +250,7 @@ void Reconcile() {
     SDL_Joystick* joystick = nullptr;
     if (enabled) {
         for (uint32_t port = 0; port < PAD_CHANMAX; ++port) {
-            SDL_Joystick* candidate = JoystickForPort(port);
-            if (candidate != nullptr &&
-                (IsKnownWheel(candidate) || RuntimeConfigFile::FfbForceWheel())) {
+            if (SDL_Joystick* candidate = WheelForPort(port)) {
                 wheelPort = port;
                 joystick = candidate;
                 break;
@@ -331,13 +339,10 @@ void Tick() {
         return;
     }
     const bool stale = now - g_session.sineRunStamp >= kSineRefresh;
-    if (g_session.sineRunning && !stale &&
-        std::abs(target - g_session.sineMagnitude) < kVibrationEpsilon) {
-        return;
-    }
     if (std::abs(target - g_session.sineMagnitude) >= kVibrationEpsilon) {
-        g_session.sine.periodic.magnitude = static_cast<int16_t>(target);
-        if (!Guard(SDL_UpdateHapticEffect(g_session.haptic, g_session.sineId, &g_session.sine))) {
+        SDL_HapticEffect effect = SineEffect();
+        effect.periodic.magnitude = static_cast<int16_t>(target);
+        if (!Guard(SDL_UpdateHapticEffect(g_session.haptic, g_session.sineId, &effect))) {
             return;
         }
         g_session.sineMagnitude = static_cast<int16_t>(target);
@@ -363,11 +368,7 @@ bool OnMotorCommand(int32_t chan, uint32_t command) {
     return true;
 }
 
-bool IsWheelPort(uint32_t port) {
-    SDL_Joystick* joystick = JoystickForPort(port);
-    return joystick != nullptr &&
-           (IsKnownWheel(joystick) || RuntimeConfigFile::FfbForceWheel());
-}
+bool IsWheelPort(uint32_t port) { return WheelForPort(port) != nullptr; }
 
 const char* StatusText() { return g_status; }
 
@@ -411,36 +412,28 @@ void ApplySteeringSensitivity(int percent) {
 }
 
 uint32_t PedalButtons(uint32_t port) {
-    const int32_t index = PADGetIndexForPort(port);
-    if (index < 0) {
-        return 0;
-    }
-    SDL_Gamepad* gamepad = PADGetSDLGamepadForIndex(static_cast<uint32_t>(index));
-    if (gamepad == nullptr) {
-        return 0;
-    }
-    SDL_Joystick* joystick = SDL_GetGamepadJoystick(gamepad);
-    if (joystick == nullptr || !IsKnownWheel(joystick)) {
+    SDL_Joystick* joystick = WheelForPort(port);
+    if (joystick == nullptr) {
         return 0;
     }
     const int axes = SDL_GetNumJoystickAxes(joystick);
     uint32_t pressed = 0;
     if (axes > 1 && SDL_GetJoystickAxis(joystick, 1) < kPedalThreshold) {
-        pressed |= kPedalAccelerate;
+        pressed |= PAD_BUTTON_A;
     }
     if (axes > 2 && SDL_GetJoystickAxis(joystick, 2) < kPedalThreshold) {
-        pressed |= kPedalBrake;
+        pressed |= PAD_BUTTON_B;
     }
     return pressed;
 }
 
 int32_t ShapeSteering(uint32_t port, int32_t stickX) {
-    const int32_t index = PADGetIndexForPort(port);
-    if (index < 0) {
+    SDL_Joystick* joystick = WheelForPort(port);
+    if (joystick == nullptr) {
         return stickX;
     }
-    SDL_Gamepad* gamepad = PADGetSDLGamepadForIndex(static_cast<uint32_t>(index));
-    if (gamepad == nullptr || !IsKnownWheel(SDL_GetGamepadJoystick(gamepad))) {
+    SDL_Gamepad* gamepad = SDL_GetGamepadFromID(SDL_GetJoystickID(joystick));
+    if (gamepad == nullptr) {
         return stickX;
     }
     int32_t raw = SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFTX);

--- a/runtime/src/wheel_ffb.cpp
+++ b/runtime/src/wheel_ffb.cpp
@@ -38,7 +38,8 @@ constexpr auto kOpenBackoff = std::chrono::seconds(30);
 constexpr uint16_t kAuroraStickDeadZone = 8000;
 constexpr uint16_t kWheelStickDeadZone = 600;
 constexpr int16_t kPedalThreshold = -8000;
-constexpr auto kSpringRefresh = std::chrono::seconds(2);
+constexpr auto kSpringRefresh = std::chrono::seconds(10);
+constexpr uint32_t kSpringLength = 30000;
 
 struct Session {
     bool active = false;
@@ -127,7 +128,7 @@ SDL_HapticEffect SpringEffect(int springPercent) {
     SDL_HapticEffect effect{};
     effect.type = SDL_HAPTIC_SPRING;
     effect.condition.direction.type = SDL_HAPTIC_STEERING_AXIS;
-    effect.condition.length = 5000;
+    effect.condition.length = kSpringLength;
     const auto coeff = static_cast<int16_t>(springPercent * 0x7FFF / 100);
     effect.condition.right_sat[0] = 0xFFFF;
     effect.condition.left_sat[0] = 0xFFFF;

--- a/runtime/src/wheel_ffb.cpp
+++ b/runtime/src/wheel_ffb.cpp
@@ -392,7 +392,7 @@ void ApplyVibration(int percent) {
 }
 
 void ApplySteeringSensitivity(int percent) {
-    g_steering = std::clamp(percent, 100, 400);
+    g_steering = std::clamp(percent, 100, 900);
 }
 
 int32_t ShapeSteering(uint32_t port, int32_t stickX) {

--- a/runtime/src/wheel_ffb.cpp
+++ b/runtime/src/wheel_ffb.cpp
@@ -37,6 +37,8 @@ constexpr auto kSineRefresh = std::chrono::seconds(1);
 constexpr auto kOpenBackoff = std::chrono::seconds(30);
 constexpr uint16_t kAuroraStickDeadZone = 8000;
 constexpr uint16_t kWheelStickDeadZone = 600;
+constexpr int16_t kPedalThreshold = -8000;
+constexpr auto kSpringRefresh = std::chrono::seconds(2);
 
 struct Session {
     bool active = false;
@@ -50,6 +52,7 @@ struct Session {
     bool sineRunning = false;
     int16_t sineMagnitude = 0;
     Clock::time_point sineRunStamp{};
+    Clock::time_point springRunStamp{};
     bool motorOn = false;
     Clock::time_point motorStamp{};
     Clock::duration motorAccum{};
@@ -209,6 +212,7 @@ void OpenSession(uint32_t port, SDL_Joystick* joystick) {
         g_session.springId = SDL_CreateHapticEffect(haptic, &effect);
         springRunning = g_session.springId >= 0 &&
                         SDL_RunHapticEffect(haptic, g_session.springId, SDL_HAPTIC_INFINITY);
+        g_session.springRunStamp = Clock::now();
     }
     if (!springRunning && (g_session.features & SDL_HAPTIC_AUTOCENTER) != 0) {
         SDL_SetHapticAutocenter(haptic, g_spring);
@@ -284,6 +288,16 @@ void Tick() {
     }
     if (!g_session.active) {
         return;
+    }
+    if (g_session.springId >= 0 && now - g_session.springRunStamp >= kSpringRefresh) {
+        g_session.springRunStamp = now;
+        if ((g_session.features & SDL_HAPTIC_GAIN) != 0) {
+            SDL_SetHapticGain(g_session.haptic, g_strength);
+        }
+        SDL_HapticEffect effect = SpringEffect(g_spring);
+        if (Guard(SDL_UpdateHapticEffect(g_session.haptic, g_session.springId, &effect))) {
+            Guard(SDL_RunHapticEffect(g_session.haptic, g_session.springId, SDL_HAPTIC_INFINITY));
+        }
     }
     if (g_session.motorOn) {
         g_session.motorAccum += now - g_session.motorStamp;
@@ -393,6 +407,30 @@ void ApplyVibration(int percent) {
 
 void ApplySteeringSensitivity(int percent) {
     g_steering = std::clamp(percent, 100, 900);
+}
+
+uint32_t PedalButtons(uint32_t port) {
+    const int32_t index = PADGetIndexForPort(port);
+    if (index < 0) {
+        return 0;
+    }
+    SDL_Gamepad* gamepad = PADGetSDLGamepadForIndex(static_cast<uint32_t>(index));
+    if (gamepad == nullptr) {
+        return 0;
+    }
+    SDL_Joystick* joystick = SDL_GetGamepadJoystick(gamepad);
+    if (joystick == nullptr || !IsKnownWheel(joystick)) {
+        return 0;
+    }
+    const int axes = SDL_GetNumJoystickAxes(joystick);
+    uint32_t pressed = 0;
+    if (axes > 1 && SDL_GetJoystickAxis(joystick, 1) < kPedalThreshold) {
+        pressed |= kPedalAccelerate;
+    }
+    if (axes > 2 && SDL_GetJoystickAxis(joystick, 2) < kPedalThreshold) {
+        pressed |= kPedalBrake;
+    }
+    return pressed;
 }
 
 int32_t ShapeSteering(uint32_t port, int32_t stickX) {

--- a/runtime/src/wheel_ffb.cpp
+++ b/runtime/src/wheel_ffb.cpp
@@ -91,7 +91,10 @@ SDL_HapticID FindHaptic(SDL_Joystick* joystick) {
     const char* joystickName = SDL_GetJoystickName(joystick);
     for (int i = 0; i < count; ++i) {
         const char* name = SDL_GetHapticNameForID(ids[i]);
-        if (joystickName != nullptr && name != nullptr && std::strcmp(name, joystickName) == 0) {
+        if (joystickName == nullptr || name == nullptr || *joystickName == '\0' || *name == '\0') {
+            continue;
+        }
+        if (std::strstr(joystickName, name) != nullptr || std::strstr(name, joystickName) != nullptr) {
             chosen = ids[i];
             break;
         }

--- a/runtime/src/wheel_ffb.cpp
+++ b/runtime/src/wheel_ffb.cpp
@@ -19,10 +19,10 @@ namespace {
 using Clock = std::chrono::steady_clock;
 
 constexpr uint16_t kLogitechVid = 0x046D;
-constexpr uint16_t kWheelPids[] = {
-    0xC202, 0xC20E, 0xC293, 0xC294, 0xC295, 0xC298, 0xC299, 0xC29A, 0xC29B, 0xC29C,
-    0xC24F, 0xC260, 0xC261, 0xC262, 0xC266, 0xC267, 0xC268, 0xC26D, 0xC26E, 0xC272,
-    0xCA03, 0xCA04,
+constexpr uint16_t kUnlistedWheelPids[] = {0xC202, 0xC20E, 0xC293, 0xC29C, 0xCA04};
+constexpr uint16_t kDrivingForcePids[] = {
+    0xC202, 0xC20E, 0xC24F, 0xC260, 0xC293, 0xC294, 0xC295,
+    0xC298, 0xC299, 0xC29A, 0xC29B, 0xC29C, 0xCA03, 0xCA04,
 };
 
 constexpr float kVibrationFloor = 2600.0f;
@@ -38,6 +38,8 @@ constexpr auto kOpenBackoff = std::chrono::seconds(30);
 constexpr uint16_t kAuroraStickDeadZone = 8000;
 constexpr uint16_t kWheelStickDeadZone = 600;
 constexpr int16_t kPedalThreshold = -8000;
+constexpr int16_t kPedalRestZone = 24000;
+constexpr int kMaxTrackedAxes = 8;
 constexpr auto kSpringRefresh = std::chrono::seconds(10);
 constexpr uint32_t kSpringLength = 30000;
 
@@ -70,9 +72,10 @@ int g_strength = RuntimeConfigFile::FfbStrength();
 int g_spring = RuntimeConfigFile::FfbSpring();
 int g_vibration = RuntimeConfigFile::FfbVibration();
 int g_steering = RuntimeConfigFile::SteeringSensitivity();
+bool g_restsHigh[kMaxTrackedAxes] = {};
 
 bool IsKnownWheel(SDL_Joystick* joystick) {
-    return IsWheelDevice(SDL_GetJoystickVendor(joystick), SDL_GetJoystickProduct(joystick));
+    return IsWheelInstance(SDL_GetJoystickID(joystick));
 }
 
 SDL_Joystick* JoystickForPort(uint32_t port) {
@@ -89,10 +92,7 @@ SDL_Joystick* WheelForPort(uint32_t port) {
     if (joystick == nullptr) {
         return nullptr;
     }
-    if (!IsKnownWheel(joystick) && !RuntimeConfigFile::FfbForceWheel()) {
-        return nullptr;
-    }
-    return joystick;
+    return IsKnownWheel(joystick) ? joystick : nullptr;
 }
 
 bool NamesRelated(const char* joystickName, const char* hapticName) {
@@ -281,9 +281,28 @@ void Reconcile() {
 
 } // namespace
 
-bool IsWheelDevice(uint16_t vendor, uint16_t product) {
-    return vendor == kLogitechVid &&
-           std::find(std::begin(kWheelPids), std::end(kWheelPids), product) != std::end(kWheelPids);
+bool IsWheelInstance(uint32_t instance) {
+    if (SDL_GetJoystickTypeForID(instance) == SDL_JOYSTICK_TYPE_WHEEL) {
+        return true;
+    }
+    if (RuntimeConfigFile::FfbForceWheel()) {
+        return true;
+    }
+    if (SDL_GetJoystickVendorForID(instance) != kLogitechVid) {
+        return false;
+    }
+    const uint16_t product = SDL_GetJoystickProductForID(instance);
+    return std::find(std::begin(kUnlistedWheelPids), std::end(kUnlistedWheelPids), product) !=
+           std::end(kUnlistedWheelPids);
+}
+
+bool HasBuiltinLayout(uint32_t instance) {
+    if (SDL_GetJoystickVendorForID(instance) != kLogitechVid) {
+        return false;
+    }
+    const uint16_t product = SDL_GetJoystickProductForID(instance);
+    return std::find(std::begin(kDrivingForcePids), std::end(kDrivingForcePids), product) !=
+           std::end(kDrivingForcePids);
 }
 
 void NotifyControllersChanged() { g_dirty = true; }
@@ -416,12 +435,45 @@ uint32_t PedalButtons(uint32_t port) {
     if (joystick == nullptr) {
         return 0;
     }
-    const int axes = SDL_GetNumJoystickAxes(joystick);
+    const int axes = std::min(SDL_GetNumJoystickAxes(joystick), kMaxTrackedAxes);
+    for (int axis = 1; axis < axes; ++axis) {
+        const int16_t value = SDL_GetJoystickAxis(joystick, axis);
+        if (value > kPedalRestZone) {
+            g_restsHigh[axis] = true;
+        }
+    }
+    if (axes == 2) {
+        const int16_t value = SDL_GetJoystickAxis(joystick, 1);
+        if (g_restsHigh[1]) {
+            return value < kPedalThreshold ? PAD_BUTTON_A : 0;
+        }
+        if (value < kPedalThreshold) {
+            return PAD_BUTTON_A;
+        }
+        return value > -kPedalThreshold ? PAD_BUTTON_B : 0;
+    }
+    int accel = RuntimeConfigFile::AcceleratorAxis();
+    int brake = RuntimeConfigFile::BrakeAxis();
+    if (accel < 0 || brake < 0) {
+        int found[2] = {-1, -1};
+        int count = 0;
+        for (int axis = 1; axis < axes && count < 2; ++axis) {
+            if (g_restsHigh[axis]) {
+                found[count++] = axis;
+            }
+        }
+        if (accel < 0) {
+            accel = count > 0 ? found[0] : 1;
+        }
+        if (brake < 0) {
+            brake = count > 1 ? found[1] : 2;
+        }
+    }
     uint32_t pressed = 0;
-    if (axes > 1 && SDL_GetJoystickAxis(joystick, 1) < kPedalThreshold) {
+    if (accel < axes && SDL_GetJoystickAxis(joystick, accel) < kPedalThreshold) {
         pressed |= PAD_BUTTON_A;
     }
-    if (axes > 2 && SDL_GetJoystickAxis(joystick, 2) < kPedalThreshold) {
+    if (brake < axes && SDL_GetJoystickAxis(joystick, brake) < kPedalThreshold) {
         pressed |= PAD_BUTTON_B;
     }
     return pressed;

--- a/runtime/src/wheel_ffb.cpp
+++ b/runtime/src/wheel_ffb.cpp
@@ -305,7 +305,10 @@ bool HasBuiltinLayout(uint32_t instance) {
            std::end(kDrivingForcePids);
 }
 
-void NotifyControllersChanged() { g_dirty = true; }
+void NotifyControllersChanged() {
+    g_dirty = true;
+    std::fill(std::begin(g_restsHigh), std::end(g_restsHigh), false);
+}
 
 void Tick() {
     const auto now = Clock::now();
@@ -436,44 +439,39 @@ uint32_t PedalButtons(uint32_t port) {
         return 0;
     }
     const int axes = std::min(SDL_GetNumJoystickAxes(joystick), kMaxTrackedAxes);
-    for (int axis = 1; axis < axes; ++axis) {
-        const int16_t value = SDL_GetJoystickAxis(joystick, axis);
-        if (value > kPedalRestZone) {
-            g_restsHigh[axis] = true;
-        }
-    }
     if (axes == 2) {
         const int16_t value = SDL_GetJoystickAxis(joystick, 1);
-        if (g_restsHigh[1]) {
-            return value < kPedalThreshold ? PAD_BUTTON_A : 0;
-        }
         if (value < kPedalThreshold) {
             return PAD_BUTTON_A;
         }
         return value > -kPedalThreshold ? PAD_BUTTON_B : 0;
     }
+    int learned[2] = {-1, -1};
+    int count = 0;
+    for (int axis = 1; axis < axes; ++axis) {
+        if (SDL_GetJoystickAxis(joystick, axis) > kPedalRestZone) {
+            g_restsHigh[axis] = true;
+        }
+        if (g_restsHigh[axis] && count < 2) {
+            learned[count++] = axis;
+        }
+    }
     int accel = RuntimeConfigFile::AcceleratorAxis();
     int brake = RuntimeConfigFile::BrakeAxis();
-    if (accel < 0 || brake < 0) {
-        int found[2] = {-1, -1};
-        int count = 0;
-        for (int axis = 1; axis < axes && count < 2; ++axis) {
-            if (g_restsHigh[axis]) {
-                found[count++] = axis;
-            }
-        }
-        if (accel < 0) {
-            accel = count > 0 ? found[0] : 1;
-        }
-        if (brake < 0) {
-            brake = count > 1 ? found[1] : 2;
-        }
+    if (accel < 0) {
+        accel = count > 0 ? learned[0] : 1;
+    }
+    if (brake < 0) {
+        brake = count > 1 ? learned[1] : accel + 1;
+    }
+    if (brake == accel) {
+        brake = -1;
     }
     uint32_t pressed = 0;
-    if (accel < axes && SDL_GetJoystickAxis(joystick, accel) < kPedalThreshold) {
+    if (accel > 0 && accel < axes && SDL_GetJoystickAxis(joystick, accel) < kPedalThreshold) {
         pressed |= PAD_BUTTON_A;
     }
-    if (brake < axes && SDL_GetJoystickAxis(joystick, brake) < kPedalThreshold) {
+    if (brake > 0 && brake < axes && SDL_GetJoystickAxis(joystick, brake) < kPedalThreshold) {
         pressed |= PAD_BUTTON_B;
     }
     return pressed;

--- a/runtime/src/wheel_ffb.cpp
+++ b/runtime/src/wheel_ffb.cpp
@@ -34,6 +34,9 @@ constexpr auto kRetryDelay = std::chrono::seconds(2);
 constexpr int kMaxFailures = 8;
 constexpr uint32_t kSineIterations = 4;
 constexpr auto kSineRefresh = std::chrono::seconds(1);
+constexpr auto kOpenBackoff = std::chrono::seconds(30);
+constexpr uint16_t kAuroraStickDeadZone = 8000;
+constexpr uint16_t kWheelStickDeadZone = 600;
 
 struct Session {
     bool active = false;
@@ -63,13 +66,10 @@ const char* g_status = "No force feedback device found";
 int g_strength = RuntimeConfigFile::FfbStrength();
 int g_spring = RuntimeConfigFile::FfbSpring();
 int g_vibration = RuntimeConfigFile::FfbVibration();
+int g_steering = RuntimeConfigFile::SteeringSensitivity();
 
 bool IsKnownWheel(SDL_Joystick* joystick) {
-    if (SDL_GetJoystickVendor(joystick) != kLogitechVid) {
-        return false;
-    }
-    const uint16_t pid = SDL_GetJoystickProduct(joystick);
-    return std::find(std::begin(kWheelPids), std::end(kWheelPids), pid) != std::end(kWheelPids);
+    return IsWheelDevice(SDL_GetJoystickVendor(joystick), SDL_GetJoystickProduct(joystick));
 }
 
 SDL_Joystick* JoystickForPort(uint32_t port) {
@@ -81,26 +81,40 @@ SDL_Joystick* JoystickForPort(uint32_t port) {
     return gamepad != nullptr ? SDL_GetGamepadJoystick(gamepad) : nullptr;
 }
 
-SDL_HapticID FindHaptic(SDL_Joystick* joystick) {
+bool NamesRelated(const char* joystickName, const char* hapticName) {
+    if (joystickName == nullptr || hapticName == nullptr || *joystickName == '\0' ||
+        *hapticName == '\0') {
+        return false;
+    }
+    return std::strstr(joystickName, hapticName) != nullptr ||
+           std::strstr(hapticName, joystickName) != nullptr;
+}
+
+SDL_Haptic* OpenMatchingHaptic(SDL_Joystick* joystick) {
     int count = 0;
     SDL_HapticID* ids = SDL_GetHaptics(&count);
     if (ids == nullptr) {
-        return 0;
+        return nullptr;
     }
-    SDL_HapticID chosen = 0;
     const char* joystickName = SDL_GetJoystickName(joystick);
-    for (int i = 0; i < count; ++i) {
-        const char* name = SDL_GetHapticNameForID(ids[i]);
-        if (joystickName == nullptr || name == nullptr || *joystickName == '\0' || *name == '\0') {
-            continue;
+    SDL_Haptic* chosen = nullptr;
+    for (int pass = 0; pass < 2 && chosen == nullptr; ++pass) {
+        for (int i = 0; i < count; ++i) {
+            const bool related = NamesRelated(joystickName, SDL_GetHapticNameForID(ids[i]));
+            if (pass == 0 ? !related : related) {
+                continue;
+            }
+            SDL_Haptic* haptic = SDL_OpenHaptic(ids[i]);
+            if (haptic == nullptr) {
+                continue;
+            }
+            if (SDL_GetNumHapticAxes(haptic) >= 1 &&
+                (SDL_GetHapticFeatures(haptic) & (SDL_HAPTIC_SPRING | SDL_HAPTIC_CONSTANT)) != 0) {
+                chosen = haptic;
+                break;
+            }
+            SDL_CloseHaptic(haptic);
         }
-        if (std::strstr(joystickName, name) != nullptr || std::strstr(name, joystickName) != nullptr) {
-            chosen = ids[i];
-            break;
-        }
-    }
-    if (chosen == 0 && count == 1 && IsKnownWheel(joystick)) {
-        chosen = ids[0];
     }
     SDL_free(ids);
     return chosen;
@@ -160,17 +174,15 @@ bool Guard(bool ok) {
 }
 
 void OpenSession(uint32_t port, SDL_Joystick* joystick) {
-    const SDL_HapticID id = FindHaptic(joystick);
-    if (id == 0) {
-        g_status = "No force feedback device found";
-        return;
-    }
-    SDL_Haptic* haptic = SDL_OpenHaptic(id);
+    SDL_Haptic* haptic = OpenMatchingHaptic(joystick);
     if (haptic == nullptr) {
-        RT_LOG(RT_TAG_CONFIG) << "wheel ffb: failed to open haptic device: " << SDL_GetError()
+        RT_LOG(RT_TAG_CONFIG) << "wheel ffb: no usable haptic device for "
+                              << (SDL_GetJoystickName(joystick) != nullptr
+                                      ? SDL_GetJoystickName(joystick)
+                                      : "wheel")
                               << std::endl;
-        g_status = "Failed to open force feedback device";
-        g_retryAfter = Clock::now() + kRetryDelay;
+        g_status = "No force feedback device found";
+        g_retryAfter = Clock::now() + kOpenBackoff;
         return;
     }
     g_session.active = true;
@@ -182,6 +194,11 @@ void OpenSession(uint32_t port, SDL_Joystick* joystick) {
     g_session.windowStart = g_session.motorStamp;
     if (SDL_Gamepad* gamepad = SDL_GetGamepadFromID(g_session.instance)) {
         SDL_RumbleGamepad(gamepad, 0, 0, 0);
+    }
+    if (PADDeadZones* zones = PADGetDeadZones(port)) {
+        if (zones->stickDeadZone == kAuroraStickDeadZone) {
+            zones->stickDeadZone = kWheelStickDeadZone;
+        }
     }
     if ((g_session.features & SDL_HAPTIC_GAIN) != 0) {
         SDL_SetHapticGain(haptic, g_strength);
@@ -250,6 +267,11 @@ void Reconcile() {
 }
 
 } // namespace
+
+bool IsWheelDevice(uint16_t vendor, uint16_t product) {
+    return vendor == kLogitechVid &&
+           std::find(std::begin(kWheelPids), std::end(kWheelPids), product) != std::end(kWheelPids);
+}
 
 void NotifyControllersChanged() { g_dirty = true; }
 
@@ -367,6 +389,27 @@ void ApplySpring(int percent) {
 
 void ApplyVibration(int percent) {
     g_vibration = std::clamp(percent, 0, 100);
+}
+
+void ApplySteeringSensitivity(int percent) {
+    g_steering = std::clamp(percent, 100, 400);
+}
+
+int32_t ShapeSteering(uint32_t port, int32_t stickX) {
+    const int32_t index = PADGetIndexForPort(port);
+    if (index < 0) {
+        return stickX;
+    }
+    SDL_Gamepad* gamepad = PADGetSDLGamepadForIndex(static_cast<uint32_t>(index));
+    if (gamepad == nullptr || !IsKnownWheel(SDL_GetGamepadJoystick(gamepad))) {
+        return stickX;
+    }
+    int32_t raw = SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFTX);
+    if (std::abs(raw) <= kWheelStickDeadZone) {
+        return 0;
+    }
+    raw = raw > 0 ? raw - kWheelStickDeadZone : raw + kWheelStickDeadZone;
+    return std::clamp(raw * g_steering / (100 * 256), -127, 127);
 }
 
 } // namespace wheel_ffb

--- a/runtime/src/wheel_ffb.cpp
+++ b/runtime/src/wheel_ffb.cpp
@@ -1,0 +1,369 @@
+#include "wheel_ffb.h"
+#include "runtime_config.h"
+#include "runtime_log.h"
+
+#include <SDL3/SDL_gamepad.h>
+#include <SDL3/SDL_haptic.h>
+#include <SDL3/SDL_joystick.h>
+#include <dolphin/pad.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+
+namespace wheel_ffb {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+constexpr uint16_t kLogitechVid = 0x046D;
+constexpr uint16_t kWheelPids[] = {
+    0xC202, 0xC20E, 0xC293, 0xC294, 0xC295, 0xC298, 0xC299, 0xC29A, 0xC29B, 0xC29C,
+    0xC24F, 0xC260, 0xC261, 0xC262, 0xC266, 0xC267, 0xC268, 0xC26D, 0xC26E, 0xC272,
+    0xCA03, 0xCA04,
+};
+
+constexpr float kVibrationFloor = 2600.0f;
+constexpr int kVibrationEpsilon = 655;
+constexpr uint16_t kSpringDeadband = 0x0CCD;
+constexpr auto kDutyWindow = std::chrono::milliseconds(100);
+constexpr auto kReconcileInterval = std::chrono::seconds(1);
+constexpr auto kRetryDelay = std::chrono::seconds(2);
+constexpr int kMaxFailures = 8;
+constexpr uint32_t kSineIterations = 4;
+constexpr auto kSineRefresh = std::chrono::seconds(1);
+
+struct Session {
+    bool active = false;
+    uint32_t port = 0;
+    SDL_JoystickID instance = 0;
+    SDL_Haptic* haptic = nullptr;
+    uint32_t features = 0;
+    SDL_HapticEffectID springId = -1;
+    SDL_HapticEffectID sineId = -1;
+    SDL_HapticEffect sine{};
+    bool sineRunning = false;
+    int16_t sineMagnitude = 0;
+    Clock::time_point sineRunStamp{};
+    bool motorOn = false;
+    Clock::time_point motorStamp{};
+    Clock::duration motorAccum{};
+    Clock::time_point windowStart{};
+    float level = 0.0f;
+    int failures = 0;
+};
+
+Session g_session;
+bool g_dirty = true;
+Clock::time_point g_nextReconcile{};
+Clock::time_point g_retryAfter{};
+const char* g_status = "No force feedback device found";
+int g_strength = RuntimeConfigFile::FfbStrength();
+int g_spring = RuntimeConfigFile::FfbSpring();
+int g_vibration = RuntimeConfigFile::FfbVibration();
+
+bool IsKnownWheel(SDL_Joystick* joystick) {
+    if (SDL_GetJoystickVendor(joystick) != kLogitechVid) {
+        return false;
+    }
+    const uint16_t pid = SDL_GetJoystickProduct(joystick);
+    return std::find(std::begin(kWheelPids), std::end(kWheelPids), pid) != std::end(kWheelPids);
+}
+
+SDL_Joystick* JoystickForPort(uint32_t port) {
+    const int32_t index = PADGetIndexForPort(port);
+    if (index < 0) {
+        return nullptr;
+    }
+    SDL_Gamepad* gamepad = PADGetSDLGamepadForIndex(static_cast<uint32_t>(index));
+    return gamepad != nullptr ? SDL_GetGamepadJoystick(gamepad) : nullptr;
+}
+
+SDL_HapticID FindHaptic(SDL_Joystick* joystick) {
+    int count = 0;
+    SDL_HapticID* ids = SDL_GetHaptics(&count);
+    if (ids == nullptr) {
+        return 0;
+    }
+    SDL_HapticID chosen = 0;
+    const char* joystickName = SDL_GetJoystickName(joystick);
+    for (int i = 0; i < count; ++i) {
+        const char* name = SDL_GetHapticNameForID(ids[i]);
+        if (joystickName != nullptr && name != nullptr && std::strcmp(name, joystickName) == 0) {
+            chosen = ids[i];
+            break;
+        }
+    }
+    if (chosen == 0 && count == 1 && IsKnownWheel(joystick)) {
+        chosen = ids[0];
+    }
+    SDL_free(ids);
+    return chosen;
+}
+
+SDL_HapticEffect SpringEffect(int springPercent) {
+    SDL_HapticEffect effect{};
+    effect.type = SDL_HAPTIC_SPRING;
+    effect.condition.direction.type = SDL_HAPTIC_STEERING_AXIS;
+    effect.condition.length = 5000;
+    const auto coeff = static_cast<int16_t>(springPercent * 0x7FFF / 100);
+    effect.condition.right_sat[0] = 0xFFFF;
+    effect.condition.left_sat[0] = 0xFFFF;
+    effect.condition.right_coeff[0] = coeff;
+    effect.condition.left_coeff[0] = coeff;
+    effect.condition.deadband[0] = kSpringDeadband;
+    return effect;
+}
+
+SDL_HapticEffect SineEffect() {
+    SDL_HapticEffect effect{};
+    effect.type = SDL_HAPTIC_SINE;
+    effect.periodic.direction.type = SDL_HAPTIC_STEERING_AXIS;
+    effect.periodic.period = 50;
+    effect.periodic.length = 1000;
+    effect.periodic.magnitude = 0;
+    return effect;
+}
+
+void CloseSession(const char* status) {
+    if (g_session.haptic != nullptr) {
+        if (g_session.sineId >= 0) {
+            SDL_DestroyHapticEffect(g_session.haptic, g_session.sineId);
+        }
+        if (g_session.springId >= 0) {
+            SDL_DestroyHapticEffect(g_session.haptic, g_session.springId);
+        }
+        SDL_CloseHaptic(g_session.haptic);
+        RT_LOG(RT_TAG_CONFIG) << "wheel ffb: closed session on port " << g_session.port + 1
+                              << std::endl;
+    }
+    g_session = Session{};
+    g_status = status;
+}
+
+bool Guard(bool ok) {
+    if (ok) {
+        g_session.failures = 0;
+        return true;
+    }
+    RT_LOG(RT_TAG_CONFIG) << "wheel ffb: effect call failed: " << SDL_GetError() << std::endl;
+    if (++g_session.failures >= kMaxFailures) {
+        CloseSession("Device error, retrying");
+        g_retryAfter = Clock::now() + kRetryDelay;
+    }
+    return false;
+}
+
+void OpenSession(uint32_t port, SDL_Joystick* joystick) {
+    const SDL_HapticID id = FindHaptic(joystick);
+    if (id == 0) {
+        g_status = "No force feedback device found";
+        return;
+    }
+    SDL_Haptic* haptic = SDL_OpenHaptic(id);
+    if (haptic == nullptr) {
+        RT_LOG(RT_TAG_CONFIG) << "wheel ffb: failed to open haptic device: " << SDL_GetError()
+                              << std::endl;
+        g_status = "Failed to open force feedback device";
+        g_retryAfter = Clock::now() + kRetryDelay;
+        return;
+    }
+    g_session.active = true;
+    g_session.port = port;
+    g_session.instance = SDL_GetJoystickID(joystick);
+    g_session.haptic = haptic;
+    g_session.features = SDL_GetHapticFeatures(haptic);
+    g_session.motorStamp = Clock::now();
+    g_session.windowStart = g_session.motorStamp;
+    if (SDL_Gamepad* gamepad = SDL_GetGamepadFromID(g_session.instance)) {
+        SDL_RumbleGamepad(gamepad, 0, 0, 0);
+    }
+    if ((g_session.features & SDL_HAPTIC_GAIN) != 0) {
+        SDL_SetHapticGain(haptic, g_strength);
+    }
+    bool springRunning = false;
+    if ((g_session.features & SDL_HAPTIC_SPRING) != 0) {
+        SDL_HapticEffect effect = SpringEffect(g_spring);
+        g_session.springId = SDL_CreateHapticEffect(haptic, &effect);
+        springRunning = g_session.springId >= 0 &&
+                        SDL_RunHapticEffect(haptic, g_session.springId, SDL_HAPTIC_INFINITY);
+    }
+    if (!springRunning && (g_session.features & SDL_HAPTIC_AUTOCENTER) != 0) {
+        SDL_SetHapticAutocenter(haptic, g_spring);
+    }
+    if ((g_session.features & SDL_HAPTIC_SINE) != 0) {
+        g_session.sine = SineEffect();
+        g_session.sineId = SDL_CreateHapticEffect(haptic, &g_session.sine);
+    }
+    if (springRunning) {
+        g_status = g_session.sineId >= 0 ? "Active" : "Active, no vibration support";
+    } else if ((g_session.features & SDL_HAPTIC_AUTOCENTER) != 0) {
+        g_status = "Active, autocenter fallback";
+    } else {
+        g_status = "Active, no centering support";
+    }
+    const char* name = SDL_GetJoystickName(joystick);
+    RT_LOG(RT_TAG_CONFIG) << "wheel ffb: opened " << (name != nullptr ? name : "wheel")
+                          << " on port " << port + 1 << " (" << g_status << ")" << std::endl;
+}
+
+void Reconcile() {
+    const bool enabled = RuntimeConfigFile::FfbEnabled();
+    uint32_t wheelPort = UINT32_MAX;
+    SDL_Joystick* joystick = nullptr;
+    if (enabled) {
+        for (uint32_t port = 0; port < PAD_CHANMAX; ++port) {
+            SDL_Joystick* candidate = JoystickForPort(port);
+            if (candidate != nullptr &&
+                (IsKnownWheel(candidate) || RuntimeConfigFile::FfbForceWheel())) {
+                wheelPort = port;
+                joystick = candidate;
+                break;
+            }
+        }
+    }
+    if (wheelPort == UINT32_MAX) {
+        const char* status = enabled ? "No force feedback device found" : "Force feedback off";
+        if (g_session.active) {
+            CloseSession(status);
+        } else {
+            g_status = status;
+        }
+        return;
+    }
+    if (g_session.active && g_session.port == wheelPort &&
+        g_session.instance == SDL_GetJoystickID(joystick)) {
+        return;
+    }
+    if (g_session.active) {
+        CloseSession("No force feedback device found");
+    }
+    if (Clock::now() < g_retryAfter) {
+        return;
+    }
+    OpenSession(wheelPort, joystick);
+}
+
+} // namespace
+
+void NotifyControllersChanged() { g_dirty = true; }
+
+void Tick() {
+    const auto now = Clock::now();
+    if (g_dirty || now >= g_nextReconcile) {
+        g_dirty = false;
+        g_nextReconcile = now + kReconcileInterval;
+        Reconcile();
+    }
+    if (!g_session.active) {
+        return;
+    }
+    if (g_session.motorOn) {
+        g_session.motorAccum += now - g_session.motorStamp;
+        g_session.motorStamp = now;
+    }
+    const auto elapsed = now - g_session.windowStart;
+    if (elapsed < kDutyWindow) {
+        return;
+    }
+    const float duty =
+        std::clamp(std::chrono::duration<float>(g_session.motorAccum).count() /
+                       std::chrono::duration<float>(elapsed).count(),
+                   0.0f, 1.0f);
+    g_session.motorAccum = {};
+    g_session.windowStart = now;
+    g_session.level += (duty - g_session.level) * 0.3f;
+    if (g_session.sineId < 0) {
+        return;
+    }
+    int target = 0;
+    if (g_session.level >= 0.02f) {
+        const float base = kVibrationFloor + g_session.level * (32767.0f - kVibrationFloor);
+        target = static_cast<int>(base * static_cast<float>(g_vibration) / 100.0f);
+    }
+    if (target == 0) {
+        if (g_session.sineRunning && Guard(SDL_StopHapticEffect(g_session.haptic, g_session.sineId))) {
+            g_session.sineRunning = false;
+            g_session.sineMagnitude = 0;
+        }
+        return;
+    }
+    const bool stale = now - g_session.sineRunStamp >= kSineRefresh;
+    if (g_session.sineRunning && !stale &&
+        std::abs(target - g_session.sineMagnitude) < kVibrationEpsilon) {
+        return;
+    }
+    if (std::abs(target - g_session.sineMagnitude) >= kVibrationEpsilon) {
+        g_session.sine.periodic.magnitude = static_cast<int16_t>(target);
+        if (!Guard(SDL_UpdateHapticEffect(g_session.haptic, g_session.sineId, &g_session.sine))) {
+            return;
+        }
+        g_session.sineMagnitude = static_cast<int16_t>(target);
+    }
+    if ((!g_session.sineRunning || stale) &&
+        Guard(SDL_RunHapticEffect(g_session.haptic, g_session.sineId, kSineIterations))) {
+        g_session.sineRunning = true;
+        g_session.sineRunStamp = now;
+    }
+}
+
+bool OnMotorCommand(int32_t chan, uint32_t command) {
+    if (!g_session.active || g_session.sineId < 0 ||
+        static_cast<uint32_t>(chan) != g_session.port) {
+        return false;
+    }
+    const auto now = Clock::now();
+    if (g_session.motorOn) {
+        g_session.motorAccum += now - g_session.motorStamp;
+    }
+    g_session.motorStamp = now;
+    g_session.motorOn = command == PAD_MOTOR_RUMBLE;
+    return true;
+}
+
+bool IsWheelPort(uint32_t port) {
+    SDL_Joystick* joystick = JoystickForPort(port);
+    return joystick != nullptr &&
+           (IsKnownWheel(joystick) || RuntimeConfigFile::FfbForceWheel());
+}
+
+const char* StatusText() { return g_status; }
+
+float SteeringPosition() {
+    if (!g_session.active) {
+        return 0.0f;
+    }
+    SDL_Gamepad* gamepad = SDL_GetGamepadFromID(g_session.instance);
+    if (gamepad == nullptr) {
+        return 0.0f;
+    }
+    return static_cast<float>(SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFTX)) / 32767.0f;
+}
+
+void ApplyStrength(int percent) {
+    g_strength = std::clamp(percent, 0, 100);
+    if (g_session.active && (g_session.features & SDL_HAPTIC_GAIN) != 0) {
+        SDL_SetHapticGain(g_session.haptic, g_strength);
+    }
+}
+
+void ApplySpring(int percent) {
+    g_spring = std::clamp(percent, 0, 100);
+    if (!g_session.active) {
+        return;
+    }
+    if (g_session.springId >= 0) {
+        SDL_HapticEffect effect = SpringEffect(g_spring);
+        Guard(SDL_UpdateHapticEffect(g_session.haptic, g_session.springId, &effect));
+    } else if ((g_session.features & SDL_HAPTIC_AUTOCENTER) != 0) {
+        SDL_SetHapticAutocenter(g_session.haptic, g_spring);
+    }
+}
+
+void ApplyVibration(int percent) {
+    g_vibration = std::clamp(percent, 0, 100);
+}
+
+} // namespace wheel_ffb


### PR DESCRIPTION
adds racing wheel support. a wheel gets recognised on its own, the pedals and
the wheel reach the game properly, and force feedback runs a centering spring
plus vibration off the game's own rumble.

built and tested against a logitech g29 on windows with g hub. the pedals, the
steering and the force feedback have all been driven on that wheel and work.
everything below was tried on it unless it says otherwise.

## how it works

a wheel that sdl recognises is treated as a wheel: force feedback, steering
that uses the whole rotation, pedals on a and b. sdl keeps its own wheel list,
about 70 devices across 13 vendors, so this isn't limited to the wheels named
here. it covers the logitech line, thrustmaster, fanatec, moza, simagic,
simucube, asetek, cammus, vrs and pxn. `force_wheel = true` under `[ffb]` picks
up the ones sdl doesn't know, like mad catz and hori.

logitech driving force wheels also get a full button layout with no setup,
since their layout is known. any other wheel plays right away but takes its
buttons from the set up wizard that's already there, and a mapping you capture
in the wizard always wins over the built-in one.

## why the pedals are read in the runtime

sdl's windows backend only reports axis *changes*, so a pedal you haven't
touched reads as centred instead of released. bind that through sdl as a
button and it reads as held, so both pedals come up stuck down until you press
them. the runtime reads the raw axes instead, with a threshold that's right
whether or not the axis has reported yet.

there's also no convention across brands for which axis is which. the usual
`a1 = accelerator, a2 = brake` guess was wrong on all four non-logitech
families i checked, and thrustmaster is the exact opposite of it. it isn't even
fixed per model: a g29 only reports that order because g hub is installed, and
the same wheel without the driver puts the clutch on a1. so the pedal axes are
worked out at runtime by watching which axes sit at full deflection. wheels
that put both pedals on one axis work too, and there are accelerator and brake
selectors in the f10 menu if the guess comes out backwards.

layout detection is kept separate from wheel detection on purpose. guessing a
button layout for an unknown wheel is worse than not guessing, because sdl
would then count the wheel as mapped and the set up entry would disappear, so
there'd be no way left to fix it.

## steering

steering skips the pad layer's 8000 unit stick dead zone, which was eating
about a quarter of the wheel's travel, and has its own sensitivity setting
(default 350%, adjustable 100-900%). rotation range still belongs in the
wheel's own driver, around 270 degrees suits a kart game.

## force feedback

a spring condition effect for the centering and a sine effect for the
vibration, driven by the game's `PADControlMotor` rumble commands. no new
telemetry is involved. both effects are reissued every ten seconds, because
directinput drops a playing effect whenever the device gets reacquired, which
is what made the wheel go loose part way through a session.

picking the haptic device needs care: sdl exposes three haptic interfaces for a
g29 and only one of them has a usable force feedback axis, so it's picked by
capability and not by name.

strength, spring, vibration, steering sensitivity and the pedal axes all live
in f10 -> controller settings. they apply as you drag and are saved to
`Config.toml`.

## config

new keys, all optional:

- `[ffb] enabled`, `strength`, `spring`, `vibration`, `force_wheel`
- `[controller] steering_sensitivity`, `accelerator_axis`, `brake_axis`

## what isn't covered

- only the g29 has been on real hardware. the other wheels follow from sdl's
  device list and published layouts, not from testing.
- g920 and g923 are recognised but have known force feedback problems in sdl
  itself, nothing here can fix that.
- no telemetry driven forces, so no speed weighting or directional pulls on a
  collision. the game gives rumble on/off and the wheel position, that's it. a
  constant force effect drops into the existing session if race state hooks
  ever land.
- rotation range can't be set programmatically on windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added racing wheel support with automatic wheel and pedal detection.
  - Added built-in wheel mappings and guided controller/button setup.
  - Added configurable steering sensitivity, steering range, pedal axes, force feedback strength, centering spring, and vibration.
  - Added wheel status information and support for steering shaping and pedal controls.
  - Improved controller mapping for buttons, triggers, and analog axes.

- **Documentation**
  - Documented supported wheel brands, setup instructions, force-feedback controls, rotation guidance, known limitations, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->