### PR TITLE
CI: automatically run packaging CI on every tag

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,6 +7,9 @@ name: Package installers
 # that step requires the end user's own Mario Kart Wii dump (Assets/main.dol, Assets/StaticR.rel),
 # which is proprietary and not present in this repository or in CI.
 on:
+  push:
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
I anticipate the future workflow for cutting a release to go something like:

- make a tag locally and push that tag to github
- wait for packaging CI that automatically gets triggered to build the releases
- test the generated exe/appimage/macos package locally (if necessary)
- create a release page and upload the generated assets from the packaging CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package workflows now run automatically whenever a Git tag is pushed.
  * Manual workflow triggering remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->