### PR TITLE
Default Wii remote continuous scanning to off

### DIFF
--- a/runtime/include/runtime_config.h
+++ b/runtime/include/runtime_config.h
@@ -804,7 +804,7 @@ inline bool SetWiiRemotesEnabled(bool value) {
 }
 
 // Whether to keep rescanning Bluetooth while no Wii controller is connected.
-inline bool WiiContinuousScanEnabled(bool fallback = true) {
+inline bool WiiContinuousScanEnabled(bool fallback = false) {
     return Get().wiiContinuousScan.value_or(fallback);
 }
 

--- a/runtime/src/settings_overlay.cpp
+++ b/runtime/src/settings_overlay.cpp
@@ -321,7 +321,7 @@ void ApplyConfiguredMappings() {
 }
 
 bool g_wiiRemotesEnabled = RuntimeConfigFile::WiiRemotesEnabled(true);
-bool g_wiiContinuousScan = RuntimeConfigFile::WiiContinuousScanEnabled(true);
+bool g_wiiContinuousScan = RuntimeConfigFile::WiiContinuousScanEnabled(false);
 
 // Accelerometer readout and zero-point calibration for a bare remote / remote + Nunchuk.
 void DrawWiiRemoteAccelerometer(uint32_t port) {

--- a/runtime/src/wii_remote_input.cpp
+++ b/runtime/src/wii_remote_input.cpp
@@ -481,7 +481,7 @@ void Poll() {
         g_lastScanMs = SDL_GetTicks();
         return;
     }
-    if (!RuntimeConfigFile::WiiContinuousScanEnabled(true)) {
+    if (!RuntimeConfigFile::WiiContinuousScanEnabled(false)) {
         g_scanning = false;
         return;
     }


### PR DESCRIPTION
disable wiimote setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Wii Remote continuous scanning is now disabled by default when no saved configuration is available.
  * Existing configuration values continue to determine whether continuous scanning is enabled.
  * Users can still enable continuous scanning through the available runtime settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->