### PR TITLE
Switch back to LLVM 22 so build can succeed on at least some systems

### DIFF
--- a/Launcher/Prepare-NativePrebuilt.sh
+++ b/Launcher/Prepare-NativePrebuilt.sh
@@ -88,7 +88,7 @@ assert_file "$ninja_bin" "Portable Ninja"
 assert_file "$cc" "Portable C compiler"
 assert_file "$cxx" "Portable C++ compiler"
 assert_dir "$aurora_source" "aurora-main source tree"
-clang_binary=$(normalize "$toolchain_dir/bin/clang-23")
+clang_binary=$(normalize "$toolchain_dir/bin/clang-22")
 assert_file "$clang_binary" "Portable clang driver binary"
 
 (( parallel > 0 )) || parallel=$(nproc)

--- a/Launcher/prepare-portable-tools.sh
+++ b/Launcher/prepare-portable-tools.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 workspace=$(cd "$script_dir/.." && pwd)
 
-llvm_version=23.1.0
+llvm_version=22.1.8
 cmake_version=4.3.3
 ninja_version=1.13.2
 destination="$script_dir/artifacts/portable-tools"
@@ -52,13 +52,13 @@ done
 
 case "$arch" in
     x86_64) llvm_release_arch=X64; target_triple=x86_64-unknown-linux-gnu
-            llvm_release_sha256=18da30f77f475688a18f7704d23f9f155ae007ed9922dbed6850a9419d9fec8c
+            llvm_release_sha256=df0e1ecf16caf3489a272a5eea4eec9b0d82878f6477fa309504f918a0006384
             cmake_release_arch=x86_64
             cmake_sha256=927b2368a946c37269c3a66225ab00544e756459cdd0b5d0da438694fb9ff802
             ninja_asset=ninja-linux.zip
             ninja_sha256=5749cbc4e668273514150a80e387a957f933c6ed3f5f11e03fb30955e2bbead6 ;;
     aarch64) llvm_release_arch=ARM64; target_triple=aarch64-unknown-linux-gnu
-            llvm_release_sha256=cfb31bfc713ef453248bf5bd026312f838ad6c52c25623e987cb6a340f3050d4
+            llvm_release_sha256=805efad2bb91cb4967fa569e0881d10c0f69c04461cf671cccbae19f547acc34
             cmake_release_arch=aarch64
             cmake_sha256=9ea38356dbd3e32e51029a3e09a0f2f8e117ef4fbcaad7a21ffb36409bbd5cb4
             ninja_asset=ninja-linux-aarch64.zip
@@ -120,9 +120,9 @@ echo "prepare-portable-tools.sh: pruning to the minimal compile+link toolchain..
 
 # clang: the real driver executable plus the clang/clang++ symlinks CMake/local-build.sh invoke.
 # Stripped: debug symbols are dead weight for a bundled compiler nobody will debug.
-cp -a "$src/bin/clang-23" "$work/bin/"
-strip "$work/bin/clang-23"
-ln -s clang-23 "$work/bin/clang"
+cp -a "$src/bin/clang-22" "$work/bin/"
+strip "$work/bin/clang-22"
+ln -s clang-22 "$work/bin/clang"
 ln -s clang "$work/bin/clang++"
 
 # lld: linked via -fuse-ld=lld, which clang resolves by looking for ld.lld next to itself first -


### PR DESCRIPTION
two upstream LLVM bugs currently prevent building on some of the newest distros. There is no current LLVM release that works on them so we are pending fixes from LLVM https://github.com/patchzyy/Wiicompiled/issues/136

One was fixed in LLVM 23.1.0 https://github.com/llvm/llvm-project/commit/11a802685043cb1e9b23e54437da011bdfbf1d61 but it introduced a NEW bug that breaks even more systems that previously worked https://github.com/llvm/llvm-project/issues/215764

This at least lets the systems that did work before continue to work (Ubuntu 22.04, Ubuntu 24.04). The new release literally only works on Ubuntu 22.04 and no other distro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled LLVM toolchain to version 22.1.8.
  * Updated toolchain integrity checks for supported architectures.
  * Standardized native preprocessing and compiler hashing on Clang 22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->