### PR TITLE
Treat empty MKW save as missing rather than corrupt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ Code.pul
 /build/
 /build-*/
 /native-build/
+/native-build-macos/
+/local-products/
 /dist/
 /out/
 [Bb]in/

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -277,6 +277,10 @@ target_link_libraries(mkw_platform_paths_tests PRIVATE mkw_platform)
 target_compile_features(mkw_platform_paths_tests PRIVATE cxx_std_17)
 add_test(NAME mkw_platform_paths_tests COMMAND mkw_platform_paths_tests)
 
+add_executable(mkw_nand_save_tests "${CMAKE_CURRENT_LIST_DIR}/tests/nand_save_tests.cpp")
+target_include_directories(mkw_nand_save_tests PRIVATE "${CMAKE_CURRENT_LIST_DIR}/include")
+target_compile_features(mkw_nand_save_tests PRIVATE cxx_std_17)
+add_test(NAME mkw_nand_save_tests COMMAND mkw_nand_save_tests)
 # The input expression engine is self-contained, so it can be exercised without
 # linking the runtime or SDL.
 add_executable(mkw_input_expr_tests

--- a/runtime/include/nand_save_probe.h
+++ b/runtime/include/nand_save_probe.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <istream>
+
+namespace RuntimeNandSave {
+
+enum class Contents { Missing, Blank, Nonzero, Error };
+enum class ReadAction { Proceed, Missing, Error, RecoveryNeeded };
+
+// A failed read is not evidence that a save is blank. Check badbit before EOF:
+// an I/O failure may set both, whereas a successful short final read sets EOF.
+inline Contents InspectStream(std::istream& input) {
+    if (!input) return Contents::Error;
+    char block[4096];
+    for (;;) {
+        input.read(block, sizeof(block));
+        if (input.bad() || (input.fail() && !input.eof())) return Contents::Error;
+        for (std::streamsize i = 0; i < input.gcount(); ++i) {
+            if (block[i] != 0) return Contents::Nonzero;
+        }
+        if (input.eof()) return Contents::Blank;
+    }
+}
+
+inline Contents InspectFile(const std::filesystem::path& path) {
+    std::error_code ec;
+    const auto status = std::filesystem::symlink_status(path, ec);
+    if (ec && ec != std::errc::no_such_file_or_directory) return Contents::Error;
+    if (!std::filesystem::exists(status)) return Contents::Missing;
+    if (!std::filesystem::is_regular_file(path, ec) || ec) return Contents::Error;
+    std::ifstream input(path, std::ios::binary);
+    return InspectStream(input);
+}
+
+// Probe only read-only opens of the actual save and its exact write shadow.
+// No probe writes, removes, or repairs data, and backups are not save aliases.
+inline ReadAction CheckRead(const std::filesystem::path& path, int mode) {
+    const auto name = path.filename();
+    const bool isMain = name == "rksys.dat";
+    if (mode != 1 || (!isMain && name != "rksys.dat.nandsafe.tmp")) return ReadAction::Proceed;
+    const auto contents = InspectFile(path);
+    if (contents == Contents::Error) return ReadAction::Error;
+    if (contents == Contents::Nonzero) return ReadAction::Proceed;
+    if (isMain) {
+        auto shadow = path;
+        shadow += ".nandsafe.tmp";
+        const auto shadowContents = InspectFile(shadow);
+        if (shadowContents == Contents::Error) return ReadAction::Error;
+        // The next write normally discards an old shadow. Preserve a possible
+        // recovery source when there is no usable original, without promoting
+        // an uncommitted (and potentially incomplete) shadow to the real save.
+        if (shadowContents == Contents::Nonzero) return ReadAction::RecoveryNeeded;
+    }
+    return contents == Contents::Blank ? ReadAction::Missing : ReadAction::Proceed;
+}
+
+} // namespace RuntimeNandSave

--- a/runtime/src/hle/storage/nand_api.cpp
+++ b/runtime/src/hle/storage/nand_api.cpp
@@ -93,6 +93,9 @@ extern "C" int32_t NANDOpen_HLE(uint32_t pathPtr, uint32_t fileInfoPtr, uint32_t
 
     const std::filesystem::path hostPath = TranslateNandPath(path);
 
+    if (NandIgnoreUninitializedSaveRead("NANDOpen", hostPath, mode))
+        return NAND_RESULT_NOEXISTS;
+
     // Existing-file write opens go through a shadow copy seeded from the original, so a
     // crash between NANDWrite and NANDClose cannot leave a torn file (the game patches
     // sub-ranges, e.g. ghost saves at a non-zero offset). New files still create in place.
@@ -136,10 +139,7 @@ extern "C" int32_t NANDOpen_HLE(uint32_t pathPtr, uint32_t fileInfoPtr, uint32_t
         }
     }
 
-    const char* fopenMode = "rb";
-    if (mode == 1) fopenMode = "rb";
-    else if (mode == 2) fopenMode = "r+b";
-    else if (mode == 3) fopenMode = "r+b";
+    const char* fopenMode = (mode == 2 || mode == 3) ? "r+b" : "rb";
     
     FILE* file = NandFopen(hostPath, fopenMode);
     if (!file && mode >= 2) {

--- a/runtime/src/hle/storage/nand_api.cpp
+++ b/runtime/src/hle/storage/nand_api.cpp
@@ -139,7 +139,10 @@ extern "C" int32_t NANDOpen_HLE(uint32_t pathPtr, uint32_t fileInfoPtr, uint32_t
         }
     }
 
-    const char* fopenMode = (mode == 2 || mode == 3) ? "r+b" : "rb";
+    const char* fopenMode = "rb";
+    if (mode == 1) fopenMode = "rb";
+    else if (mode == 2) fopenMode = "r+b";
+    else if (mode == 3) fopenMode = "r+b";
     
     FILE* file = NandFopen(hostPath, fopenMode);
     if (!file && mode >= 2) {

--- a/runtime/src/hle/storage/nand_api.cpp
+++ b/runtime/src/hle/storage/nand_api.cpp
@@ -93,8 +93,8 @@ extern "C" int32_t NANDOpen_HLE(uint32_t pathPtr, uint32_t fileInfoPtr, uint32_t
 
     const std::filesystem::path hostPath = TranslateNandPath(path);
 
-    if (NandIgnoreUninitializedSaveRead("NANDOpen", hostPath, mode))
-        return NAND_RESULT_NOEXISTS;
+    if (const auto result = NandCheckSystemSaveRead("NANDOpen", hostPath, mode))
+        return *result;
 
     // Existing-file write opens go through a shadow copy seeded from the original, so a
     // crash between NANDWrite and NANDClose cannot leave a torn file (the game patches

--- a/runtime/src/hle/storage/nand_async.cpp
+++ b/runtime/src/hle/storage/nand_async.cpp
@@ -411,6 +411,8 @@ extern "C" int32_t NANDSafeOpen_HLE(uint32_t pathPtr, uint32_t fileInfoPtr, uint
     if (mode == 1) {
         // Read-only safe open reads the original in place; the library builds no scratch
         // copy for this case.
+        if (NandIgnoreUninitializedSaveRead("NANDSafeOpen", hostPath, mode))
+            return NAND_RESULT_NOEXISTS;
         FILE* file = NandFopen(hostPath, "rb");
         if (!file && IsFaceLibResourcePath(path) && SeedFaceLibResource(hostPath)) {
             file = NandFopen(hostPath, "rb");

--- a/runtime/src/hle/storage/nand_async.cpp
+++ b/runtime/src/hle/storage/nand_async.cpp
@@ -411,8 +411,8 @@ extern "C" int32_t NANDSafeOpen_HLE(uint32_t pathPtr, uint32_t fileInfoPtr, uint
     if (mode == 1) {
         // Read-only safe open reads the original in place; the library builds no scratch
         // copy for this case.
-        if (NandIgnoreUninitializedSaveRead("NANDSafeOpen", hostPath, mode))
-            return NAND_RESULT_NOEXISTS;
+        if (const auto result = NandCheckSystemSaveRead("NANDSafeOpen", hostPath, mode))
+            return *result;
         FILE* file = NandFopen(hostPath, "rb");
         if (!file && IsFaceLibResourcePath(path) && SeedFaceLibResource(hostPath)) {
             file = NandFopen(hostPath, "rb");

--- a/runtime/src/hle/storage/nand_fs.cpp
+++ b/runtime/src/hle/storage/nand_fs.cpp
@@ -411,6 +411,39 @@ bool IsFaceLibResourcePath(const char* path) {
     return std::strcmp(path, "/shared2/menu/FaceLib/RFL_Res.dat") == 0;
 }
 
+bool NandSystemSaveIsUninitialized(const std::filesystem::path& hostPath) {
+    if (!IsNandSystemSavePath(hostPath))
+        return false;
+
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(hostPath, ec) || ec)
+        return false;
+
+    std::ifstream in(hostPath, std::ios::binary);
+    if (!in)
+        return false;
+
+    char block[4096];
+    while (in) {
+        in.read(block, sizeof(block));
+        const std::streamsize got = in.gcount();
+
+        for (std::streamsize i = 0; i < got; ++i)
+            if (block[i] != 0)
+                return false;
+    }
+    return true;
+}
+
+bool NandIgnoreUninitializedSaveRead(const char* who,
+                                     const std::filesystem::path& hostPath, int mode) {
+    if (mode != 1 || !NandSystemSaveIsUninitialized(hostPath))
+        return false;
+    LogNandWarning(who, "ignoring uninitialized system save '%s' (no save committed yet)",
+                   HostPathText(hostPath).c_str());
+    return true;
+}
+
 // Create directories recursively
 bool CreateDirectoryPath(const std::filesystem::path& path) {
     if (path.empty()) {

--- a/runtime/src/hle/storage/nand_fs.cpp
+++ b/runtime/src/hle/storage/nand_fs.cpp
@@ -411,37 +411,24 @@ bool IsFaceLibResourcePath(const char* path) {
     return std::strcmp(path, "/shared2/menu/FaceLib/RFL_Res.dat") == 0;
 }
 
-bool NandSystemSaveIsUninitialized(const std::filesystem::path& hostPath) {
-    if (!IsNandSystemSavePath(hostPath))
-        return false;
-
-    std::error_code ec;
-    if (!std::filesystem::is_regular_file(hostPath, ec) || ec)
-        return false;
-
-    std::ifstream in(hostPath, std::ios::binary);
-    if (!in)
-        return false;
-
-    char block[4096];
-    while (in) {
-        in.read(block, sizeof(block));
-        const std::streamsize got = in.gcount();
-
-        for (std::streamsize i = 0; i < got; ++i)
-            if (block[i] != 0)
-                return false;
+std::optional<int32_t> NandCheckSystemSaveRead(const char* who,
+    const std::filesystem::path& hostPath, int mode, bool ios) {
+    const auto action = RuntimeNandSave::CheckRead(hostPath, mode);
+    if (action == RuntimeNandSave::ReadAction::Proceed) return std::nullopt;
+    if (action == RuntimeNandSave::ReadAction::Missing) {
+        LogNandWarning(who, "treating empty or zero-filled system save '%s' as missing",
+                       HostPathText(hostPath).c_str());
+        return ios ? ISFS_ENOENT : NAND_RESULT_NOEXISTS;
     }
-    return true;
-}
-
-bool NandIgnoreUninitializedSaveRead(const char* who,
-                                     const std::filesystem::path& hostPath, int mode) {
-    if (mode != 1 || !NandSystemSaveIsUninitialized(hostPath))
-        return false;
-    LogNandWarning(who, "ignoring uninitialized system save '%s' (no save committed yet)",
-                   HostPathText(hostPath).c_str());
-    return true;
+    if (action == RuntimeNandSave::ReadAction::RecoveryNeeded) {
+        LogNandError(who, "system save '%s' is missing or blank but its .nandsafe.tmp contains data; "
+                         "back up both files before attempting recovery",
+                     HostPathText(hostPath).c_str());
+    } else {
+        LogNandError(who, "could not inspect system save '%s' or its write shadow; leaving data untouched",
+                     HostPathText(hostPath).c_str());
+    }
+    return ios ? ISFS_EIO : NAND_RESULT_UNKNOWN;
 }
 
 // Create directories recursively

--- a/runtime/src/hle/storage/nand_internal.h
+++ b/runtime/src/hle/storage/nand_internal.h
@@ -56,6 +56,25 @@ constexpr uint32_t kNandTitleIdLo = 0x524D4350; // "RMCP" fallback
 void LogNandError(const char* func, const char* fmt, ...);
 void LogNandWarning(const char* func, const char* fmt, ...);
 
+// The Mario Kart Wii system save (rksys.dat) and its ".nandsafe.tmp" write shadows.
+inline bool IsNandSystemSavePath(const std::filesystem::path& path) {
+    const std::string name = path.filename().string();
+    return name == "rksys.dat" || name.rfind("rksys.dat", 0) == 0;
+}
+
+// True when a system save exists on the host but holds no committed save yet: the game
+// zero-fills rksys.dat during its first-run "format save data" step and only writes the
+// real database (which always begins with the RKSD0006 header) once it actually saves.
+// An all-zero file therefore contains nothing worth loading; read it as absent so the
+// game recreates its save instead of entering the corrupt-save recovery loop.
+bool NandSystemSaveIsUninitialized(const std::filesystem::path& hostPath);
+
+// Read-open helper: logs and returns true when a read of this system save should see
+// "no save". Centralizes the mode == 1 guard and warning so the NAND, NANDSafe and IOS
+// open paths share one branch and message.
+bool NandIgnoreUninitializedSaveRead(const char* who, const std::filesystem::path& hostPath,
+                                     int mode);
+
 // ============================================================================
 // File Descriptor Management
 // ============================================================================

--- a/runtime/src/hle/storage/nand_internal.h
+++ b/runtime/src/hle/storage/nand_internal.h
@@ -69,9 +69,7 @@ inline bool IsNandSystemSavePath(const std::filesystem::path& path) {
 // game recreates its save instead of entering the corrupt-save recovery loop.
 bool NandSystemSaveIsUninitialized(const std::filesystem::path& hostPath);
 
-// Read-open helper: logs and returns true when a read of this system save should see
-// "no save". Centralizes the mode == 1 guard and warning so the NAND, NANDSafe and IOS
-// open paths share one branch and message.
+// Read-open helper: logs and returns true when a read of this system save should see "no save".
 bool NandIgnoreUninitializedSaveRead(const char* who, const std::filesystem::path& hostPath,
                                      int mode);
 

--- a/runtime/src/hle/storage/nand_internal.h
+++ b/runtime/src/hle/storage/nand_internal.h
@@ -9,6 +9,7 @@
 #include "hle/runtime_parse_helpers.h"
 #include "memory.h"
 #include "nand_path.h"
+#include "nand_save_probe.h"
 #include "hle/net/network.h"
 #include "recomp_mod_loader.h"
 #include "runtime_config.h"
@@ -26,6 +27,7 @@
 #include <deque>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <vector>
 #include <filesystem>
 #include <string>
@@ -56,22 +58,10 @@ constexpr uint32_t kNandTitleIdLo = 0x524D4350; // "RMCP" fallback
 void LogNandError(const char* func, const char* fmt, ...);
 void LogNandWarning(const char* func, const char* fmt, ...);
 
-// The Mario Kart Wii system save (rksys.dat) and its ".nandsafe.tmp" write shadows.
-inline bool IsNandSystemSavePath(const std::filesystem::path& path) {
-    const std::string name = path.filename().string();
-    return name == "rksys.dat" || name.rfind("rksys.dat", 0) == 0;
-}
-
-// True when a system save exists on the host but holds no committed save yet: the game
-// zero-fills rksys.dat during its first-run "format save data" step and only writes the
-// real database (which always begins with the RKSD0006 header) once it actually saves.
-// An all-zero file therefore contains nothing worth loading; read it as absent so the
-// game recreates its save instead of entering the corrupt-save recovery loop.
-bool NandSystemSaveIsUninitialized(const std::filesystem::path& hostPath);
-
-// Read-open helper: logs and returns true when a read of this system save should see "no save".
-bool NandIgnoreUninitializedSaveRead(const char* who, const std::filesystem::path& hostPath,
-                                     int mode);
+// An empty optional means continue opening normally; otherwise return the
+// supplied NAND/IOS error without exposing a failed scan as a missing save.
+std::optional<int32_t> NandCheckSystemSaveRead(const char* who,
+    const std::filesystem::path& hostPath, int mode, bool ios = false);
 
 // ============================================================================
 // File Descriptor Management

--- a/runtime/src/hle/storage/nand_isfs.cpp
+++ b/runtime/src/hle/storage/nand_isfs.cpp
@@ -392,8 +392,8 @@ extern "C" int32_t NAND_IOS_Open_HLE(uint32_t pathPtr, uint32_t mode) {
     // It's a NAND file path
     const std::filesystem::path hostPath = TranslateNandPath(path);
 
-    if (NandIgnoreUninitializedSaveRead("IOS_Open", hostPath, mode))
-        return ISFS_ENOENT;
+    if (const auto result = NandCheckSystemSaveRead("IOS_Open", hostPath, mode, true))
+        return *result;
     
     // Seed FaceLib resources before the existence check so every open mode can
     // still find them on a fresh managed NAND.

--- a/runtime/src/hle/storage/nand_isfs.cpp
+++ b/runtime/src/hle/storage/nand_isfs.cpp
@@ -391,6 +391,9 @@ extern "C" int32_t NAND_IOS_Open_HLE(uint32_t pathPtr, uint32_t mode) {
     
     // It's a NAND file path
     const std::filesystem::path hostPath = TranslateNandPath(path);
+
+    if (NandIgnoreUninitializedSaveRead("IOS_Open", hostPath, mode))
+        return ISFS_ENOENT;
     
     // Seed FaceLib resources before the existence check so every open mode can
     // still find them on a fresh managed NAND.

--- a/runtime/tests/nand_save_tests.cpp
+++ b/runtime/tests/nand_save_tests.cpp
@@ -1,0 +1,138 @@
+#include "nand_save_probe.h"
+#include "nand_settings.h"
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+namespace fs = std::filesystem;
+using RuntimeNandSave::ReadAction;
+using RuntimeNandSave::Contents;
+
+static void Require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+static void Write(const fs::path& path, const std::string& bytes) {
+    fs::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::binary);
+    output.write(bytes.data(), bytes.size());
+    output.close();
+    Require(static_cast<bool>(output), "Fixture write failed");
+}
+
+static std::string Read(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    Require(static_cast<bool>(input), "Fixture read failed");
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+// A disk error after zero-filled blocks must not look like a blank file's EOF.
+class FailingDisk : public std::streambuf {
+    int blocks;
+public:
+    explicit FailingDisk(int zeroBlocks) : blocks(zeroBlocks) {}
+    std::streamsize xsgetn(char* buffer, std::streamsize length) override {
+        if (blocks-- <= 0) throw std::runtime_error("injected read failure");
+        std::fill(buffer, buffer + length, '\0');
+        return length;
+    }
+};
+
+int main() {
+    const auto root = fs::temp_directory_path() / ("wiicomp-save-scenarios-" +
+        std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+    try {
+        const auto save = root / "title/00010004/524d4350/data/rksys.dat";
+        const auto shadow = fs::path(save.native() + fs::path(".nandsafe.tmp").native());
+        std::string error;
+        Require(RuntimeNandSettings::Ensure(root, error, 1800000123), "New profile settings bootstrap");
+        const auto identity = Read(RuntimeNandSettings::FilePath(root));
+        Require(RuntimeNandSave::CheckRead(save, 1) == ReadAction::Proceed, "Fresh profile follows normal missing-file handling");
+        Require(!fs::exists(save), "Probing fresh profile must not create a save");
+
+        // First launch interrupted before save initialization, including block
+        // boundaries and a full-sized synthetic zero-filled allocation.
+        for (const size_t size : {size_t(0), size_t(1), size_t(4095), size_t(4096), size_t(4097), size_t(3 * 1024 * 1024)}) {
+            const std::string bytes(size, '\0');
+            Write(save, bytes);
+            Require(RuntimeNandSave::CheckRead(save, 1) == ReadAction::Missing, "Blank save should be offered first-save recovery");
+            Require(Read(save) == bytes, "Blank-save detection must not modify the file");
+            for (int mode : {2, 3}) {
+                Require(RuntimeNandSave::CheckRead(save, mode) == ReadAction::Proceed, "Write opens must remain available for initialization");
+            }
+        }
+
+        // Existing saves, imported saves, partial/corrupt saves, and a zero
+        // prefix with data only in the final byte are all left to the game.
+        std::string existing(3 * 1024 * 1024, '\0');
+        existing.replace(0, 8, "RKSD0006");
+        existing[10000] = 42;
+        for (const std::string& bytes : {existing, std::string("RKSD"), std::string("damaged-header"),
+                 std::string(8192, '\0') + "x", std::string(8191, '\0') + "x"}) {
+            Write(save, bytes);
+            Require(RuntimeNandSave::CheckRead(save, 1) == ReadAction::Proceed, "Never hide a save containing any data");
+            Require(Read(save) == bytes, "Existing/partial save must be byte-identical after inspection");
+        }
+
+        // Interrupted replacement: retain a committed original regardless of
+        // whether the shadow is blank, partial, or contains a complete header.
+        Write(save, existing);
+        for (const std::string& bytes : {std::string(), std::string(4096, '\0'), std::string("RKSD"), existing}) {
+            Write(shadow, bytes);
+            Require(RuntimeNandSave::CheckRead(save, 1) == ReadAction::Proceed, "Committed original takes precedence over write shadow");
+            Require(Read(save) == existing && Read(shadow) == bytes, "Probe must preserve both sides of an interrupted write");
+        }
+        // No usable original: do not let missing-save recovery discard the
+        // only possible recovery source, and do not auto-promote that shadow.
+        for (const bool mainExists : {false, true}) {
+            fs::remove(save);
+            if (mainExists) Write(save, std::string(4096, '\0'));
+            Write(shadow, existing);
+            Require(RuntimeNandSave::CheckRead(save, 1) == ReadAction::RecoveryNeeded, "Preserve recovery candidate when original is missing or blank");
+            Require(Read(shadow) == existing, "Recovery candidate must remain unchanged");
+            Require(fs::exists(save) == mainExists, "Do not promote shadow automatically");
+        }
+        Write(shadow, std::string(4096, '\0'));
+        Require(RuntimeNandSave::CheckRead(save, 1) == ReadAction::Missing, "Two blank files may use first-save recovery");
+        fs::remove(shadow);
+
+        for (const char* name : {"rksys.dat.bak", "rksys.dat.backup", "rksys.dat2", "banner.bin", "setting.txt"}) {
+            const auto unrelated = save.parent_path() / name;
+            Write(unrelated, std::string(4096, '\0'));
+            Require(RuntimeNandSave::CheckRead(unrelated, 1) == ReadAction::Proceed, "Do not classify backups or unrelated files as missing saves");
+        }
+        for (int blocks : {0, 1, 2}) {
+            FailingDisk disk(blocks);
+            std::istream input(&disk);
+            Require(RuntimeNandSave::InspectStream(input) == Contents::Error, "Read failure must remain an error, including after zero-filled blocks");
+        }
+        std::istringstream badEof;
+        badEof.setstate(std::ios::badbit | std::ios::eofbit);
+        Require(RuntimeNandSave::InspectStream(badEof) == Contents::Error, "Badbit plus EOF must not imply a blank save");
+
+#ifdef _WIN32
+        Write(save, existing);
+        const HANDLE locked = CreateFileW(save.c_str(), GENERIC_READ, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        Require(locked != INVALID_HANDLE_VALUE, "Could not lock fixture");
+        const auto lockedResult = RuntimeNandSave::CheckRead(save, 1);
+        CloseHandle(locked);
+        Require(lockedResult == ReadAction::Error, "Sharing/access failure must not report a missing save");
+        Require(Read(save) == existing, "Locked save must survive inspection unchanged");
+        Require(SetFileAttributesW(save.c_str(), FILE_ATTRIBUTE_READONLY) != 0, "Set fixture read-only");
+        const auto readOnlyResult = RuntimeNandSave::CheckRead(save, 1);
+        SetFileAttributesW(save.c_str(), FILE_ATTRIBUTE_NORMAL);
+        Require(readOnlyResult == ReadAction::Proceed && Read(save) == existing, "Readable read-only save remains available");
+#endif
+        Require(RuntimeNandSettings::Ensure(root, error, 1900000123), "Existing profile settings bootstrap");
+        Require(Read(RuntimeNandSettings::FilePath(root)) == identity, "Save recovery must not change console identity");
+        fs::remove_all(root);
+        std::cout << "NAND save startup, preservation, interrupted-write and I/O failure scenarios passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << error.what() << " (fixtures retained at " << root << ")\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
When the game is first ran, the `rksys.dat` file is zero-filled before any in-game saves occur. 

Quitting before the first save (like creating a license) leaves `rksys.dat` as all-zeroes; read by the game as corrupt which put me in a delete/recreate loop. Opening up the game  for the first time real quick to see if it works and then turning it off before creating a new license is probably a somewhat common flow, so a protection here is useful in my opinion.

The fix I propose is to treat an all-zero `rksys.dat` file as an `absent` state, like a console without a first-save.

This was validated as working on an ARM64 MacOS 27 device, I'll do a before & after on a x86-Linux & x86-Win11 device soon for coverage's sake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of system saves during read and open operations.
  - Blank or incomplete save data is now recognized as unavailable instead of being processed as valid data.
  - Existing non-empty saves, including saves with unexpected or corrupt content, are preserved.
  - Interrupted save writes are detected more reliably, helping prevent invalid data from being opened.
  - Read failures and recovery-required conditions now produce appropriate errors rather than being treated as missing saves.
- **Tests**
  - Expanded coverage for save inspection, recovery, corruption, I/O failures, and platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->