### PR TITLE
Feature/apple silicon wheelwizard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,32 @@ jobs:
 
       - name: Test
         run: dotnet test translator/Translator.sln -c Release --no-build --verbosity normal
+
+  macos_substrate:
+    name: macOS arm64 (configure + substrate tests)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Configure native runtime
+        shell: bash
+        run: |
+          test "$(uname -m)" = arm64
+          cmake -S runtime -B build-macos -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DMKW_BUILD_PRODUCTS=OFF
+
+      - name: Build macOS portability targets
+        shell: bash
+        run: |
+          cmake --build build-macos --target \
+            mkw_platform_paths_tests \
+            mkw_macos_native_compile \
+            mkw_macos_context_abi_tests \
+            mkw_macos_host_context_tests \
+            mkw_macos_guest_flat_memory_tests
+
+      - name: Test execution substrate
+        shell: bash
+        run: ctest --test-dir build-macos --output-on-failure

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -162,6 +162,23 @@ jobs:
             --output Launcher/dist/WiiCompiled-Setup.pkg \
             --version "$package_version"
 
+      - name: Build WheelWizard setup asset
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+          TAG_VERSION: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          package_version="${PACKAGE_VERSION:-${TAG_VERSION#v}}"
+          mkdir -p Launcher/artifacts/wheelwizard-tools
+          cp Launcher/artifacts/macos/nodtool Launcher/artifacts/wheelwizard-tools/
+          cp Launcher/artifacts/macos/translator/Translator.Cli Launcher/artifacts/wheelwizard-tools/
+          cp "$(command -v ninja)" Launcher/artifacts/wheelwizard-tools/ninja
+          ditto Launcher/artifacts/macos/cmake Launcher/artifacts/wheelwizard-tools/cmake
+          Launcher/macos/build-wheelwizard-setup.command \
+            --tools-root Launcher/artifacts/wheelwizard-tools \
+            --version "$package_version" \
+            --output Launcher/dist/WiiCompiled-Setup-macos-arm64.run
+
       - name: Verify package boundary
         shell: bash
         run: |
@@ -172,9 +189,10 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: WiiCompiled-Setup-macos-arm64
-          path: Launcher/dist/WiiCompiled-Setup.pkg
+          path: |
+            Launcher/dist/WiiCompiled-Setup.pkg
+            Launcher/dist/WiiCompiled-Setup-macos-arm64.run
           if-no-files-found: error
-          archive: false
 
   # Publishes the packaged installers as a GitHub Release whenever a v* tag is pushed. Wheel Wizard
   # discovers updates from these releases, so the contract it relies on is enforced here: a full
@@ -229,7 +247,7 @@ jobs:
           set -euo pipefail
           ls -lR artifacts
           assets=()
-          for name in WiiCompiled-Setup.exe WiiCompiled-Setup-x86_64.AppImage WiiCompiled-Setup-aarch64.AppImage WiiCompiled-Setup.pkg; do
+          for name in WiiCompiled-Setup.exe WiiCompiled-Setup-x86_64.AppImage WiiCompiled-Setup-aarch64.AppImage WiiCompiled-Setup.pkg WiiCompiled-Setup-macos-arm64.run; do
             found="$(find artifacts -type f -name "$name" | head -n 1)"
             [ -n "$found" ] && [ -s "$found" ] || { echo "::error::missing release asset $name"; exit 1; }
             assets+=("$found")

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,8 +1,8 @@
 name: Package installers
 
 # Builds the per-platform installer/setup tool (WiiCompiled-Setup.exe /
-# WiiCompiled-Setup-x86_64.AppImage) via Launcher/Build-Installer.ps1 and
-# Launcher/build-appimage.sh respectively - the same scripts a maintainer runs by hand today to
+# WiiCompiled-Setup-x86_64.AppImage / WiiCompiled-Setup.pkg) via the platform packaging scripts -
+# the same scripts a maintainer runs by hand today to
 # produce a GitHub Release asset. This does NOT build the actual translated game executable:
 # that step requires the end user's own Mario Kart Wii dump (Assets/main.dol, Assets/StaticR.rel),
 # which is proprietary and not present in this repository or in CI.
@@ -11,6 +11,11 @@ on:
     tags:
       - '*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: Package version
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -86,14 +91,99 @@ jobs:
           if-no-files-found: error
           archive: false
 
+  macos-setup-package:
+    name: macOS (Setup.pkg, Apple Silicon)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Verify Apple Silicon runner tools
+        shell: bash
+        run: |
+          test "$(uname -m)" = arm64
+          xcode-select -p
+          command -v ninja
+          file "$(command -v ninja)" | grep -q arm64
+
+      - name: Download pinned nodtool release
+        shell: bash
+        run: |
+          mkdir -p Launcher/artifacts/macos
+          nodtool_version=v2.0.0-alpha.10
+          nodtool_asset=nodtool-macos-arm64
+          nodtool_sha256=e23ca466999b720c55e6d29c9683fce8cc74451ba64ead2e543d50129f24528a
+          curl -fsSL --retry 3 \
+            "https://github.com/encounter/nod/releases/download/${nodtool_version}/${nodtool_asset}" \
+            -o Launcher/artifacts/macos/nodtool
+          printf '%s  %s\n' "$nodtool_sha256" Launcher/artifacts/macos/nodtool | shasum -a 256 -c -
+          chmod +x Launcher/artifacts/macos/nodtool
+          Launcher/artifacts/macos/nodtool --version
+
+      - name: Publish self-contained translator
+        shell: bash
+        run: |
+          dotnet publish translator/src/Translator.Cli/Translator.Cli.csproj \
+            -c Release -r osx-arm64 --self-contained true \
+            -p:PublishSingleFile=true \
+            -o Launcher/artifacts/macos/translator
+
+      - name: Download pinned portable CMake
+        shell: bash
+        run: |
+          cmake_version=4.4.3
+          archive="cmake-${cmake_version}-macos-universal.tar.gz"
+          base_url="https://github.com/Kitware/CMake/releases/download/v${cmake_version}"
+          expected_sha256=0c5d65251c14cc884bfa16bdbed3c263ce5bffe2e21c0d0d00962cb0610464fa
+          curl -fsSL --retry 3 "$base_url/$archive" -o "$archive"
+          printf '%s  %s\n' "$expected_sha256" "$archive" | shasum -a 256 -c -
+          tar -xzf "$archive"
+          mv "cmake-${cmake_version}-macos-universal/CMake.app/Contents" Launcher/artifacts/macos/cmake
+
+      - name: Build Setup.pkg
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+          TAG_VERSION: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          package_version="$PACKAGE_VERSION"
+          if [[ -z "$package_version" ]]; then package_version="${TAG_VERSION#v}"; fi
+          mkdir -p Launcher/dist
+          Launcher/macos/build-setup-pkg.command \
+            --nodtool Launcher/artifacts/macos/nodtool \
+            --translator Launcher/artifacts/macos/translator/Translator.Cli \
+            --cmake-root Launcher/artifacts/macos/cmake \
+            --ninja "$(command -v ninja)" \
+            --output Launcher/dist/WiiCompiled-Setup.pkg \
+            --version "$package_version"
+
+      - name: Verify package boundary
+        shell: bash
+        run: |
+          pkgutil --check-signature Launcher/dist/WiiCompiled-Setup.pkg
+          ! pkgutil --payload-files Launcher/dist/WiiCompiled-Setup.pkg | \
+            grep -E '/(Assets|generated|PulsarPacks|WiiCompiled.app|RetroRewind.app)(/|$)'
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: WiiCompiled-Setup-macos-arm64
+          path: Launcher/dist/WiiCompiled-Setup.pkg
+          if-no-files-found: error
+          archive: false
+
   # Publishes the packaged installers as a GitHub Release whenever a v* tag is pushed. Wheel Wizard
   # discovers updates from these releases, so the contract it relies on is enforced here: a full
-  # (non-prerelease) release whose tag is v<semver>, carrying an asset named exactly
-  # WiiCompiled-Setup.exe, produced by a setup host that reports that same version.
+  # (non-prerelease) release whose tag is v<semver>, carrying the expected platform assets,
+  # produced by setup hosts that report that same version.
   release:
     name: Publish GitHub Release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [linux-appimage, windows-installer]
+    needs: [linux-appimage, windows-installer, macos-setup-package]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -139,7 +229,7 @@ jobs:
           set -euo pipefail
           ls -lR artifacts
           assets=()
-          for name in WiiCompiled-Setup.exe WiiCompiled-Setup-x86_64.AppImage WiiCompiled-Setup-aarch64.AppImage; do
+          for name in WiiCompiled-Setup.exe WiiCompiled-Setup-x86_64.AppImage WiiCompiled-Setup-aarch64.AppImage WiiCompiled-Setup.pkg; do
             found="$(find artifacts -type f -name "$name" | head -n 1)"
             [ -n "$found" ] && [ -s "$found" ] || { echo "::error::missing release asset $name"; exit 1; }
             assets+=("$found")

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -131,6 +131,7 @@ jobs:
           dotnet publish translator/src/Translator.Cli/Translator.Cli.csproj \
             -c Release -r osx-arm64 --self-contained true \
             -p:PublishSingleFile=true \
+            -p:IncludeNativeLibrariesForSelfExtract=true \
             -o Launcher/artifacts/macos/translator
 
       - name: Download pinned portable CMake

--- a/Launcher/WiiCompiled.Setup.Common/NodToolProvider.cs
+++ b/Launcher/WiiCompiled.Setup.Common/NodToolProvider.cs
@@ -53,15 +53,35 @@ public static class NodToolProvider
                 Architecture.X64 => "nodtool-windows-x86_64.exe",
                 Architecture.Arm64 => "nodtool-windows-arm64.exe",
                 Architecture.X86 => "nodtool-windows-x86.exe",
-                var other => throw new PlatformNotSupportedException($"No prebuilt nodtool release for Windows {other}"),
+                var other => throw new PlatformNotSupportedException(
+                    $"No prebuilt nodtool release for Windows {other}"),
             };
         }
-        return RuntimeInformation.OSArchitecture switch
+
+        if (OperatingSystem.IsMacOS())
         {
-            Architecture.X64 => "nodtool-linux-x86_64",
-            Architecture.Arm64 => "nodtool-linux-aarch64",
-            Architecture.X86 => "nodtool-linux-i686",
-            var other => throw new PlatformNotSupportedException($"No prebuilt nodtool release for Linux {other}"),
-        };
+            return RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X64 => "nodtool-macos-x86_64",
+                Architecture.Arm64 => "nodtool-macos-arm64",
+                var other => throw new PlatformNotSupportedException(
+                    $"No prebuilt nodtool release for macOS {other}"),
+            };
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            return RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X64 => "nodtool-linux-x86_64",
+                Architecture.Arm64 => "nodtool-linux-aarch64",
+                Architecture.X86 => "nodtool-linux-i686",
+                var other => throw new PlatformNotSupportedException(
+                    $"No prebuilt nodtool release for Linux {other}"),
+            };
+        }
+
+        throw new PlatformNotSupportedException("Unsupported operating system");
     }
+
 }

--- a/Launcher/WiiCompiled.Setup.MacOS.Tests/ContractTests.cs
+++ b/Launcher/WiiCompiled.Setup.MacOS.Tests/ContractTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using WiiCompiled.Setup.Common;
+using WiiCompiled.Setup.Windows;
+using Xunit;
+
+public sealed class ContractTests : IDisposable
+{
+    readonly string root = Path.Combine(Path.GetTempPath(), "mkwc-tests-" + Guid.NewGuid().ToString("N"));
+    string Install => Path.Combine(root, "Install");
+    public ContractTests() => Directory.CreateDirectory(root);
+    public void Dispose() => Directory.Delete(root, true);
+
+    [Fact]
+    public void RejectsAmbiguousOrIncompleteCommands()
+    {
+        foreach (string[] args in new string[][] { ["--silent", "--launch-base"], ["--silent", "--game"], ["--unknown"], [] })
+            Assert.Throws<ArgumentException>(() => Options.Parse(args));
+    }
+
+    [Fact]
+    public void ParsesPathsWithoutChangingSpacesQuotesOrUnicode()
+    {
+        var path = "/Users/Zoë/Games/a \"quoted\" disc.rvz";
+        var options = Options.Parse(["--silent", "--game", path, "--install-dir", Install, "--portable", "--retro-dir", root, "--download-retro-wfc-payload"]);
+        Assert.Equal(path, options.Game);
+        Assert.True(options.Download);
+        Assert.False(options.Skip);
+        Assert.True(options.Portable);
+    }
+
+    [Fact]
+    public void MissingOrOldStateCannotAuthorizeLaunch()
+    {
+        Assert.True(MacSetup.Check(Install, null, null).NeedsRepair);
+        Assert.True(MacSetup.Check(Install, new State { SchemaVersion = 0 }, null).NeedsRepair);
+    }
+
+    [Fact]
+    public void PortableRootIsFoundFromNativeAppExecutableDirectory()
+    {
+        PortableRoot.Create(root);
+        var executableDirectory = Path.Combine(Install, "RetroRewind.app", "Contents", "MacOS");
+        Directory.CreateDirectory(executableDirectory);
+        Assert.Equal(root, PortableRoot.TryFind(executableDirectory));
+        Assert.Equal(Path.Combine(root, "UserData", "Config.toml"), RuntimeConfiguration.ResolveConfigPath(executableDirectory));
+    }
+
+    [Fact]
+    public void ProductReportDetectsTamperingAndDoesNotRebuildForAssetOnlyUpdates()
+    {
+        PortableRoot.Create(root);
+        var retro = Path.Combine(root, "RetroRewind6");
+        Directory.CreateDirectory(Path.Combine(retro, "Binaries"));
+        File.WriteAllText(Path.Combine(retro, "Binaries", "Code.pul"), "compile input");
+        Directory.CreateDirectory(Path.Combine(root, "DATA"));
+        var config = RuntimeConfiguration.ResolveConfigPath(Install);
+        RuntimeConfiguration.SetDvdRoot(config, Path.Combine(root, "DATA"));
+        RuntimeConfiguration.SetRetroRewindRoot(config, retro);
+        string MakeProduct(string product)
+        {
+            var contents = Path.Combine(Install, product + ".app", "Contents");
+            Directory.CreateDirectory(Path.Combine(contents, "MacOS"));
+            Directory.CreateDirectory(Path.Combine(contents, "Resources", "wii_bootstrap"));
+            File.WriteAllText(Path.Combine(contents, "Resources", "dsp_coef.bin"), "dsp");
+            File.WriteAllText(Path.Combine(contents, "Resources", "initial_pipeline_cache.db"), "pipelines");
+            var binary = Path.Combine(contents, "MacOS", product);
+            File.WriteAllText(binary, "test executable");
+            return binary;
+        }
+        var baseBinary = MakeProduct("WiiCompiled");
+        var retroBinary = MakeProduct("RetroRewind");
+        var state = new State { SchemaVersion = 1, SetupVersion = MacSetup.Version, InstallDir = Install,
+            RetroRewindInstalled = true, RetroRoot = retro, CompileHash = CompileInputsFingerprint.Compute(retro).CompileInputsSha256,
+            ToolkitHash = MacSetup.ToolkitHash(), BaseHash = MacSetup.HashTree(Path.Combine(Install, "WiiCompiled.app")), RetroHash = MacSetup.HashTree(Path.Combine(Install, "RetroRewind.app")) };
+        Assert.False(MacSetup.Check(Install, state, retro).NeedsRepair);
+        File.WriteAllText(Path.Combine(retro, "track.szs"), "asset update");
+        Assert.False(MacSetup.Check(Install, state, retro).NeedsRepair);
+        File.WriteAllText(Path.Combine(retro, "Binaries", "Code.pul"), "new code");
+        Assert.Equal("compile-inputs-changed", MacSetup.Check(Install, state, retro).Retro.Status);
+        File.WriteAllText(baseBinary, "tampered");
+        Assert.Equal("broken", MacSetup.Check(Install, state, retro).Base.Status);
+        var serialized = JsonSerializer.Serialize(state, MacSetup.Json);
+        Assert.Contains("\"schemaVersion\":1", serialized);
+    }
+    [Fact]
+    public void InterruptedPublicationRestoresPreviousInstallAndConfiguration()
+    {
+        PortableRoot.Create(root);
+        Directory.CreateDirectory(Install + ".previous");
+        File.WriteAllText(Path.Combine(Install + ".previous", "previous.txt"), "old product");
+        Directory.CreateDirectory(Install);
+        File.WriteAllText(Path.Combine(Install, "partial.txt"), "new product");
+        var config = RuntimeConfiguration.ResolveConfigPath(Install);
+        File.WriteAllText(config, "old config");
+        var snapshot = RuntimeConfiguration.Capture(config);
+        File.WriteAllText(Install + ".config-backup", JsonSerializer.Serialize(snapshot, MacSetup.Json));
+        File.WriteAllText(config, "new config");
+        MacSetup.Recover(Install);
+        Assert.True(File.Exists(Path.Combine(Install, "previous.txt")));
+        Assert.False(File.Exists(Path.Combine(Install, "partial.txt")));
+        Assert.Equal("old config", File.ReadAllText(config));
+        Assert.False(File.Exists(Install + ".config-backup"));
+    }
+
+}

--- a/Launcher/WiiCompiled.Setup.MacOS.Tests/ContractTests.cs
+++ b/Launcher/WiiCompiled.Setup.MacOS.Tests/ContractTests.cs
@@ -83,6 +83,20 @@ public sealed class ContractTests : IDisposable
         Assert.Contains("\"schemaVersion\":1", serialized);
     }
     [Fact]
+    public void MalformedRecoveryJournalDoesNotCrashOrDeleteInstall()
+    {
+        PortableRoot.Create(root);
+        Directory.CreateDirectory(Install);
+        File.WriteAllText(Path.Combine(Install, "partial.txt"), "partial product");
+        File.WriteAllText(Install + ".config-backup", "{ malformed json");
+
+        MacSetup.Recover(Install);
+
+        Assert.True(File.Exists(Path.Combine(Install, "partial.txt")));
+        Assert.False(File.Exists(Install + ".config-backup"));
+    }
+
+    [Fact]
     public void InterruptedPublicationRestoresPreviousInstallAndConfiguration()
     {
         PortableRoot.Create(root);

--- a/Launcher/WiiCompiled.Setup.MacOS.Tests/WiiCompiled.Setup.MacOS.Tests.csproj
+++ b/Launcher/WiiCompiled.Setup.MacOS.Tests/WiiCompiled.Setup.MacOS.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <ProjectReference Include="../WiiCompiled.Setup.MacOS/WiiCompiled.Setup.MacOS.csproj" />
+  </ItemGroup>
+</Project>

--- a/Launcher/WiiCompiled.Setup.MacOS.Tests/WiiCompiled.Setup.MacOS.Tests.csproj
+++ b/Launcher/WiiCompiled.Setup.MacOS.Tests/WiiCompiled.Setup.MacOS.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Launcher/WiiCompiled.Setup.MacOS/AssemblyInfo.cs
+++ b/Launcher/WiiCompiled.Setup.MacOS/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("WiiCompiled.Setup.MacOS.Tests")]

--- a/Launcher/WiiCompiled.Setup.MacOS/InputValidation.cs
+++ b/Launcher/WiiCompiled.Setup.MacOS/InputValidation.cs
@@ -1,0 +1,6 @@
+namespace WiiCompiled.Setup.Windows;
+// Adapter for the shared Windows/Mac compile-input fingerprint implementation.
+internal static class InputValidation
+{
+    public static string Sha256File(string path) => MacSetup.Hash(path).ToLowerInvariant();
+}

--- a/Launcher/WiiCompiled.Setup.MacOS/Program.cs
+++ b/Launcher/WiiCompiled.Setup.MacOS/Program.cs
@@ -1,0 +1,330 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text.Json;
+using WiiCompiled.Setup.Common;
+using WiiCompiled.Setup.Windows;
+
+return await MacSetup.RunAsync(args);
+
+internal static class MacSetup
+{
+    internal static readonly string Version = typeof(MacSetup).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+        .InformationalVersion.Split('+')[0];
+    internal static readonly JsonSerializerOptions Json = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, PropertyNameCaseInsensitive = true };
+    static CancellationToken cancellation;
+    static readonly string Resources = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+    static void Emit(object value) => Console.WriteLine(JsonSerializer.Serialize(value, Json));
+    static int lastPercent;
+    static void Progress(string message, int percent = 10)
+    {
+        lastPercent = Math.Max(lastPercent, Math.Clamp(percent, 0, 100));
+        Emit(new { type = "progress", stage = "build", message, percent = lastPercent });
+    }
+    internal static string Hash(string path) { using var file = File.OpenRead(path); return Convert.ToHexString(SHA256.HashData(file)); }
+    static string StatePath(string install) => Path.Combine(install, "install-state.json");
+    static State? ReadState(string install) => File.Exists(StatePath(install)) ? JsonSerializer.Deserialize<State>(File.ReadAllText(StatePath(install)), Json) : null;
+    static string Executable(string install, string product) => Path.Combine(install, product + ".app", "Contents", "MacOS", product);
+
+    public static async Task<int> RunAsync(string[] args)
+    {
+        string? install = null;
+        using var cancelSource = new CancellationTokenSource();
+        cancellation = cancelSource.Token;
+        var cancellationFile = Environment.GetEnvironmentVariable("MKWCOMPILED_CANCEL_FILE");
+        var monitor = Task.Run(async () =>
+        {
+            try
+            {
+                while (!cancelSource.IsCancellationRequested)
+                {
+                    if (cancellationFile is not null && File.Exists(cancellationFile)) { cancelSource.Cancel(); break; }
+                    await Task.Delay(100, cancelSource.Token);
+                }
+            }
+            catch (OperationCanceledException) { }
+        });
+        try
+        {
+            var options = Options.Parse(args);
+            if (options.Mode == "--version") { Console.WriteLine(Version); return 0; }
+            if (!OperatingSystem.IsMacOSVersionAtLeast(14) || RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+                throw new InvalidOperationException("WiiCompiled requires macOS 14 or later and a native Apple Silicon process.");
+            install = Path.GetFullPath(options.Install ?? (options.Mode.StartsWith("--launch-") ? Path.Combine(Resources, "..") : throw new ArgumentException("--install-dir is required.")));
+            FileSystemUtilities.EnsureUsableLocation(install, "The installation directory");
+            var root = Path.GetDirectoryName(install)!;
+            // Constrain ownership: the backend only publishes into the portable Install directory.
+            if (Path.GetFileName(install) != "Install") throw new ArgumentException("The Mac backend requires a portable root's Install directory.");
+            Directory.CreateDirectory(root);
+            using var operationLock = new FileStream(Path.Combine(root, ".mkwc-operation-macos.lock"), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            Recover(install);
+            var state = ReadState(install);
+            if (options.Mode == "--check-products")
+            {
+                var report = Check(install, state, options.Retro);
+                Emit(new { type = "products", setupVersion = Version, installDir = install, rebuildRequired = report.NeedsRepair, @base = report.Base, retroRewind = report.Retro });
+                return report.NeedsRepair ? 2 : 0;
+            }
+            if (options.Mode.StartsWith("--launch-"))
+            {
+                var report = Check(install, state, state?.RetroRoot);
+                if (report.NeedsRepair) throw new InvalidOperationException("The installed products need repair before launch.");
+                var product = options.Mode == "--launch-retro" ? "RetroRewind" : "WiiCompiled";
+                var binary = Executable(install, product);
+                if (!File.Exists(binary)) throw new FileNotFoundException("The requested game is not installed.", binary);
+                // Run the Mach-O directly and wait for it, retaining the installation lock for the play session.
+                return await Run(binary, [], Path.GetDirectoryName(binary), game: true);
+            }
+            if (options.Mode == "--repair-products" && state is null) throw new InvalidOperationException("No installed state is available for repair.");
+            if (options.Mode == "--silent" && !options.Portable) throw new ArgumentException("Mac installation requires --portable.");
+            var retro = options.Retro is null ? null : RetroRewindSource.ResolveRetroRewind6(options.Retro);
+            if (retro is not null && options.Skip == options.Download) throw new ArgumentException("Choose exactly one Retro-WFC payload option with --retro-dir.");
+            await Install(install, root, state, options, retro);
+            Emit(new { type = "result", success = true, version = Version, installDir = install });
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex);
+            Emit(new { type = "result", success = false, error = ex.Message, installDir = install });
+            return 1;
+        }
+        finally { cancelSource.Cancel(); await monitor; }
+    }
+
+    internal static string HashTree(string directory)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories).Order(StringComparer.Ordinal))
+        {
+            cancellation.ThrowIfCancellationRequested();
+            hash.AppendData(System.Text.Encoding.UTF8.GetBytes(Path.GetRelativePath(directory, file) + "\0" + Hash(file) + "\n"));
+        }
+        return Convert.ToHexString(hash.GetHashAndReset());
+    }
+    internal static string ToolkitHash() => HashTree(Resources);
+
+    internal static Report Check(string install, State? state, string? retro)
+    {
+        if (state is null || state.SchemaVersion != 1 || state.SetupVersion != Version || state.InstallDir != install)
+            return new(new("toolkit-changed", "The installation identity does not match this setup."), new("toolkit-changed", "Install the current setup."));
+        if (state.ToolkitHash != ToolkitHash())
+            return new(new("toolkit-changed", "The installed source or build tools changed."), new("toolkit-changed", "Repair using a verified setup."));
+        Product CheckProduct(string name, string? expected)
+        {
+            var binary = Executable(install, name);
+            if (!File.Exists(binary) || expected is null || HashTree(Path.Combine(install, name + ".app")) != expected)
+                return new("broken", $"{name} is missing or changed.");
+            foreach (var asset in new[] { "dsp_coef.bin", "initial_pipeline_cache.db", "wii_bootstrap" })
+            {
+                var path = Path.Combine(install, name + ".app", "Contents", "Resources", asset);
+                if (!File.Exists(path) && !Directory.Exists(path)) return new("broken", $"Missing runtime asset: {asset}");
+            }
+            return new("current", "The installed product matches its inputs.");
+        }
+        var baseStatus = CheckProduct("WiiCompiled", state.BaseHash);
+        var config = RuntimeConfiguration.ResolveConfigPath(install);
+        var dvd = RuntimeConfiguration.GetResolvedPath(config, "dvd_root");
+        if (dvd is null || !Directory.Exists(dvd)) baseStatus = new("inputs-missing", "The extracted game data is missing.");
+        Product retroStatus;
+        if (!state.RetroRewindInstalled) retroStatus = new("absent", "Retro Rewind has not been built.");
+        else
+        {
+            retroStatus = CheckProduct("RetroRewind", state.RetroHash);
+            try
+            {
+                var inputs = CompileInputsFingerprint.Compute(retro ?? state.RetroRoot ?? "");
+                if (inputs.CompileInputsSha256 != state.CompileHash) retroStatus = new("compile-inputs-changed", "Retro Rewind compile inputs changed.");
+                else if (RuntimeConfiguration.GetRetroRewindRoot(config) != inputs.RetroRewindRoot)
+                    retroStatus = new("inputs-missing", "The Retro Rewind asset path needs repair.");
+            }
+            catch (Exception ex) { retroStatus = new("inputs-missing", ex.Message); }
+        }
+        return new(baseStatus, retroStatus);
+    }
+
+    static async Task Install(string install, string root, State? previous, Options options, string? retro)
+    {
+        await RunChecked("/usr/bin/xcode-select", ["-p"]);
+        var cache = Path.Combine(root, "Cache");
+        var workspace = Path.Combine(cache, "BuildWorkspace");
+        var source = Path.Combine(Resources, "workspace");
+        var tools = Path.Combine(Resources, "tools");
+        if (!File.Exists(Path.Combine(source, "projects/mkwii/recomp.yml"))) throw new FileNotFoundException("The bundled source workspace is missing.");
+        Directory.CreateDirectory(cache);
+        // Versioned source is replaced on every operation; generated output and verified disc data remain local.
+        Progress("Preparing the native Apple Silicon build", 5);
+        Directory.CreateDirectory(workspace);
+        foreach (var item in new[] { "aurora-main", "projects", "runtime", "translator", "Launcher" })
+        {
+            var destination = Path.Combine(workspace, item);
+            if (Directory.Exists(destination)) Directory.Delete(destination, true);
+            await RunChecked("/usr/bin/ditto", [Path.Combine(source, item), destination]);
+        }
+        var game = options.Game ?? previous?.GamePath;
+        if (string.IsNullOrWhiteSpace(game) || !File.Exists(game)) throw new FileNotFoundException("Select your clean PAL Mario Kart Wii disc image in WheelWizard settings.");
+        var assets = Path.Combine(workspace, "Assets");
+        // Never reuse an unverified or different disc extraction.
+        var discId = $"{Path.GetFullPath(game)}|{new FileInfo(game).Length}|{File.GetLastWriteTimeUtc(game).Ticks}";
+        var discMarker = Path.Combine(cache, "disc-source.txt");
+        var verified = File.Exists(Path.Combine(assets, "main.dol")) && File.Exists(Path.Combine(assets, "StaticR.rel"))
+            && Hash(Path.Combine(assets, "main.dol")).Equals("80d18895b39c63bd80f457398bfcbb91b7d16ac116a41a88967e954080155b05", StringComparison.OrdinalIgnoreCase)
+            && Hash(Path.Combine(assets, "StaticR.rel")).Equals("16d9d146112541fefea701ecb5bc1a496f9d50e4a752fbb5b6778e7c6399f67d", StringComparison.OrdinalIgnoreCase)
+            && File.Exists(discMarker) && File.ReadAllText(discMarker) == discId;
+        if (!verified)
+        {
+            await RunChecked("/bin/bash", [Path.Combine(workspace, "Launcher/macos/extract-disc.command"), "--game", game, "--assets-dir", assets, "--nodtool", Path.Combine(tools, "nodtool")]);
+            File.WriteAllText(discMarker, discId);
+        }
+        var payload = Path.Combine(cache, "RetroWfcPayload");
+        if (retro is not null && options.Download)
+        {
+            Progress("Preparing verified online-play support", 15);
+            try { await RetroWfcPayload.DownloadRetroWfcPayloadAsync(RetroWfcPayload.CurrentRetroWfcPayloadUri, payload, cancellation); }
+            catch (Exception) when (!cancellation.IsCancellationRequested) { RetroWfcPayload.ValidateStagedRetroWfcPayloadDirectory(payload); }
+        }
+        var staging = install + ".staging";
+        if (Directory.Exists(staging)) Directory.Delete(staging, true);
+        Directory.CreateDirectory(staging);
+        var snapshotDir = Path.Combine(cache, "CompileSnapshot");
+        if (Directory.Exists(snapshotDir)) Directory.Delete(snapshotDir, true);
+        var inputs = retro is null ? null : CompileInputsFingerprint.Snapshot(retro, snapshotDir);
+        var arguments = new List<string> { Path.Combine(workspace, "Launcher/local-build-macos.command"), "--workspace", workspace,
+            "--profile", retro is null ? "base" : "both", "--output-dir", staging,
+            "--cmake", Path.Combine(tools, "cmake/bin/cmake"), "--ninja", Path.Combine(tools, "ninja"), "--translator-bin", Path.Combine(tools, "Translator.Cli") };
+        if (retro is not null)
+        {
+            arguments.AddRange(["--base-output-dir", staging, "--retro-rewind-package-dir", inputs!.RetroRewindRoot]);
+            if (options.Skip) arguments.Add("--skip-retro-wfc-payload");
+            else arguments.AddRange(["--retro-wfc-offline-dir", payload]);
+        }
+        Progress("Compiling native game apps. The first build can take several minutes.", 20);
+        await RunChecked("/bin/bash", arguments);
+        if (retro is not null && CompileInputsFingerprint.Compute(retro).CompileInputsSha256 != inputs!.CompileInputsSha256)
+            throw new IOException("Retro Rewind changed during compilation. Retry after its update finishes.");
+        // The installed helper owns its source and tools, so repair and launch work without the original download.
+        await RunChecked("/usr/bin/ditto", [Resources, Path.Combine(staging, "Setup")]);
+        File.WriteAllText(Path.Combine(staging, "WiiCompiled-Setup.run"), "#!/bin/bash\nexec \"$(cd \"$(dirname \"$0\")\" && pwd)/Setup/WiiCompiled.Setup.MacOS\" \"$@\"\n");
+        var state = new State { SchemaVersion = 1, SetupVersion = Version, InstallDir = install, GamePath = game,
+            RetroRewindInstalled = retro is not null, RetroWfcPayloadMode = retro is null ? null : options.Skip ? "skipped" : "downloaded",
+            RetroRoot = retro, CompileHash = inputs?.CompileInputsSha256, ToolkitHash = ToolkitHash(), BaseHash = HashTree(Path.Combine(staging, "WiiCompiled.app")),
+            RetroHash = retro is null ? null : HashTree(Path.Combine(staging, "RetroRewind.app")) };
+        File.WriteAllText(StatePath(staging), JsonSerializer.Serialize(state, Json));
+        cancellation.ThrowIfCancellationRequested();
+        PortableRoot.Create(root);
+        var config = RuntimeConfiguration.ResolveConfigPath(install);
+        var oldConfig = RuntimeConfiguration.Capture(config);
+        // Store the config snapshot before moving anything, allowing the next invocation to recover after a killed process.
+        File.WriteAllText(install + ".config-backup", JsonSerializer.Serialize(oldConfig, Json));
+        var backup = install + ".previous";
+        try
+        {
+            if (Directory.Exists(install)) Directory.Move(install, backup);
+            RuntimeConfiguration.SetDvdRoot(config, Path.Combine(assets, "DATA"));
+            if (retro is not null) RuntimeConfiguration.SetRetroRewindRoot(config, retro);
+            Directory.Move(staging, install);
+            File.Delete(install + ".config-backup"); // commit point
+        }
+        catch { Recover(install); throw; }
+        if (Directory.Exists(backup)) Directory.Delete(backup, true);
+        Progress("Native installation ready", 100);
+    }
+
+    internal static void Recover(string install)
+    {
+        var journal = install + ".config-backup";
+        var backup = install + ".previous";
+        if (File.Exists(journal))
+        {
+            var snapshot = JsonSerializer.Deserialize<RuntimeConfigSnapshot>(File.ReadAllText(journal), Json)!;
+            RuntimeConfiguration.Restore(RuntimeConfiguration.ResolveConfigPath(install), snapshot);
+            if (Directory.Exists(backup))
+            {
+                if (Directory.Exists(install)) Directory.Delete(install, true);
+                Directory.Move(backup, install);
+            }
+            else if (Directory.Exists(install) && !Directory.Exists(install + ".staging")) Directory.Delete(install, true);
+            File.Delete(journal);
+        }
+        else if (Directory.Exists(backup)) Directory.Delete(backup, true);
+    }
+
+    static async Task RunChecked(string executable, IEnumerable<string> arguments)
+    {
+        var code = await Run(executable, arguments);
+        if (code != 0) throw new InvalidOperationException($"{Path.GetFileName(executable)} failed (exit {code}). See the WiiCompiled setup log for details.");
+    }
+    static async Task<int> Run(string executable, IEnumerable<string> arguments, string? cwd = null, bool game = false)
+    {
+        var start = new ProcessStartInfo(executable) { UseShellExecute = false, RedirectStandardOutput = true, RedirectStandardError = true, WorkingDirectory = cwd ?? Resources };
+        foreach (var argument in arguments) start.ArgumentList.Add(argument);
+        // Finder has a minimal PATH; all packaged tools are absolute and Apple's compiler tools live here.
+        start.Environment["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin";
+        cancellation.ThrowIfCancellationRequested();
+        using var process = Process.Start(start) ?? throw new IOException($"Could not start {executable}.");
+        async Task Drain(StreamReader reader)
+        {
+            while (await reader.ReadLineAsync() is { } line)
+            {
+                Console.Error.WriteLine(line);
+                if (!game && line.StartsWith("MKWCBUILD:STEP:")) Progress(line[15..], 35);
+            }
+        }
+        var readers = Task.WhenAll(Drain(process.StandardOutput), Drain(process.StandardError));
+        try { await process.WaitForExitAsync(cancellation); }
+        catch (OperationCanceledException)
+        {
+            if (!process.HasExited) process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync();
+            await readers;
+            throw;
+        }
+        await readers;
+        return process.ExitCode;
+    }
+}
+
+internal sealed class State
+{
+    public int SchemaVersion { get; set; }
+    public string? SetupVersion { get; set; }
+    public string? InstallDir { get; set; }
+    public string? GamePath { get; set; }
+    public bool RetroRewindInstalled { get; set; }
+    public string? RetroWfcPayloadMode { get; set; }
+    public string? RetroRoot { get; set; }
+    public string? CompileHash { get; set; }
+    public string? ToolkitHash { get; set; }
+    public string? BaseHash { get; set; }
+    public string? RetroHash { get; set; }
+}
+internal sealed record Product(string Status, string Detail) { public bool NeedsRepair => Status is not ("current" or "absent"); }
+internal sealed record Report(Product Base, Product Retro) { public bool NeedsRepair => Base.NeedsRepair || Retro.NeedsRepair; }
+internal sealed record Options(string Mode, string? Install, string? Game, string? Retro, bool Portable, bool Download, bool Skip)
+{
+    internal static Options Parse(string[] args)
+    {
+        string? mode = null, install = null, game = null, retro = null;
+        bool portable = false, download = false, skip = false;
+        for (var i = 0; i < args.Length; i++)
+        {
+            string Value() => ++i < args.Length && !string.IsNullOrWhiteSpace(args[i]) ? args[i] : throw new ArgumentException("Missing option value.");
+            switch (args[i])
+            {
+                case "--version": case "--silent": case "--repair-products": case "--check-products": case "--launch-retro": case "--launch-base":
+                    if (mode is not null) throw new ArgumentException("Choose exactly one setup operation.");
+                    mode = args[i]; break;
+                case "--install-dir": install = Value(); break;
+                case "--game": game = Value(); break;
+                case "--retro-dir": retro = Value(); break;
+                case "--portable": portable = true; break;
+                case "--download-retro-wfc-payload": download = true; break;
+                case "--skip-retro-wfc-payload": skip = true; break;
+                case "--progress-json": break;
+                default: throw new ArgumentException($"Unknown option: {args[i]}");
+            }
+        }
+        return new(mode ?? throw new ArgumentException("A setup operation is required."), install, game, retro, portable, download, skip);
+    }
+}

--- a/Launcher/WiiCompiled.Setup.MacOS/Program.cs
+++ b/Launcher/WiiCompiled.Setup.MacOS/Program.cs
@@ -24,7 +24,21 @@ internal static class MacSetup
     }
     internal static string Hash(string path) { using var file = File.OpenRead(path); return Convert.ToHexString(SHA256.HashData(file)); }
     static string StatePath(string install) => Path.Combine(install, "install-state.json");
-    static State? ReadState(string install) => File.Exists(StatePath(install)) ? JsonSerializer.Deserialize<State>(File.ReadAllText(StatePath(install)), Json) : null;
+    static State? ReadState(string install)
+{
+    if (!File.Exists(StatePath(install))) return null;
+
+    try
+    {
+        return JsonSerializer.Deserialize<State>(
+            File.ReadAllText(StatePath(install)),
+            Json);
+    }
+    catch (JsonException)
+    {
+        return null;
+    }
+}
 
     static void WriteJournal(string path, RuntimeConfigSnapshot snapshot)
     {
@@ -213,7 +227,7 @@ internal static class MacSetup
         // The installed helper owns its source and tools, so repair and launch work without the original download.
         await RunChecked("/usr/bin/ditto", [Resources, Path.Combine(staging, "Setup")]);
         var launcherScript = Path.Combine(staging, "WiiCompiled-Setup.run");
-        File.WriteAllText(launcherScript, "#!/bin/bash\\nexec \"$(cd \"$(dirname \"$0\")\" && pwd)/Setup/WiiCompiled.Setup.MacOS\" \"$@\"\\n");
+        File.WriteAllText(launcherScript, "#!/bin/bash\nexec \"$(cd \"$(dirname \"$0\")\" && pwd)/Setup/WiiCompiled.Setup.MacOS\" \"$@\"\n");
         if (!OperatingSystem.IsWindows())
         {
             File.SetUnixFileMode(launcherScript,

--- a/Launcher/WiiCompiled.Setup.MacOS/Program.cs
+++ b/Launcher/WiiCompiled.Setup.MacOS/Program.cs
@@ -25,6 +25,13 @@ internal static class MacSetup
     internal static string Hash(string path) { using var file = File.OpenRead(path); return Convert.ToHexString(SHA256.HashData(file)); }
     static string StatePath(string install) => Path.Combine(install, "install-state.json");
     static State? ReadState(string install) => File.Exists(StatePath(install)) ? JsonSerializer.Deserialize<State>(File.ReadAllText(StatePath(install)), Json) : null;
+
+    static void WriteJournal(string path, RuntimeConfigSnapshot snapshot)
+    {
+        var temp = path + ".tmp";
+        File.WriteAllText(temp, JsonSerializer.Serialize(snapshot, Json));
+        File.Move(temp, path, true);
+    }
     static string Executable(string install, string product) => Path.Combine(install, product + ".app", "Contents", "MacOS", product);
 
     public static async Task<int> RunAsync(string[] args)
@@ -205,7 +212,15 @@ internal static class MacSetup
             throw new IOException("Retro Rewind changed during compilation. Retry after its update finishes.");
         // The installed helper owns its source and tools, so repair and launch work without the original download.
         await RunChecked("/usr/bin/ditto", [Resources, Path.Combine(staging, "Setup")]);
-        File.WriteAllText(Path.Combine(staging, "WiiCompiled-Setup.run"), "#!/bin/bash\nexec \"$(cd \"$(dirname \"$0\")\" && pwd)/Setup/WiiCompiled.Setup.MacOS\" \"$@\"\n");
+        var launcherScript = Path.Combine(staging, "WiiCompiled-Setup.run");
+        File.WriteAllText(launcherScript, "#!/bin/bash\\nexec \"$(cd \"$(dirname \"$0\")\" && pwd)/Setup/WiiCompiled.Setup.MacOS\" \"$@\"\\n");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(launcherScript,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        }
         var state = new State { SchemaVersion = 1, SetupVersion = Version, InstallDir = install, GamePath = game,
             RetroRewindInstalled = retro is not null, RetroWfcPayloadMode = retro is null ? null : options.Skip ? "skipped" : "downloaded",
             RetroRoot = retro, CompileHash = inputs?.CompileInputsSha256, ToolkitHash = ToolkitHash(), BaseHash = HashTree(Path.Combine(staging, "WiiCompiled.app")),
@@ -216,7 +231,7 @@ internal static class MacSetup
         var config = RuntimeConfiguration.ResolveConfigPath(install);
         var oldConfig = RuntimeConfiguration.Capture(config);
         // Store the config snapshot before moving anything, allowing the next invocation to recover after a killed process.
-        File.WriteAllText(install + ".config-backup", JsonSerializer.Serialize(oldConfig, Json));
+        WriteJournal(install + ".config-backup", oldConfig);
         var backup = install + ".previous";
         try
         {
@@ -235,19 +250,47 @@ internal static class MacSetup
     {
         var journal = install + ".config-backup";
         var backup = install + ".previous";
+
         if (File.Exists(journal))
         {
-            var snapshot = JsonSerializer.Deserialize<RuntimeConfigSnapshot>(File.ReadAllText(journal), Json)!;
-            RuntimeConfiguration.Restore(RuntimeConfiguration.ResolveConfigPath(install), snapshot);
+            RuntimeConfigSnapshot? snapshot;
+
+            try
+            {
+                snapshot = JsonSerializer.Deserialize<RuntimeConfigSnapshot>(
+                    File.ReadAllText(journal), Json);
+            }
+            catch (JsonException)
+            {
+                snapshot = null;
+            }
+
+            if (snapshot is not null)
+            {
+                RuntimeConfiguration.Restore(
+                    RuntimeConfiguration.ResolveConfigPath(install), snapshot);
+            }
+
             if (Directory.Exists(backup))
             {
-                if (Directory.Exists(install)) Directory.Delete(install, true);
+                if (Directory.Exists(install))
+                    Directory.Delete(install, true);
+
                 Directory.Move(backup, install);
             }
-            else if (Directory.Exists(install) && !Directory.Exists(install + ".staging")) Directory.Delete(install, true);
+            else if (snapshot is not null &&
+                     Directory.Exists(install) &&
+                     !Directory.Exists(install + ".staging"))
+            {
+                Directory.Delete(install, true);
+            }
+
             File.Delete(journal);
         }
-        else if (Directory.Exists(backup)) Directory.Delete(backup, true);
+        else if (Directory.Exists(backup))
+        {
+            Directory.Delete(backup, true);
+        }
     }
 
     static async Task RunChecked(string executable, IEnumerable<string> arguments)

--- a/Launcher/WiiCompiled.Setup.MacOS/README.md
+++ b/Launcher/WiiCompiled.Setup.MacOS/README.md
@@ -1,0 +1,51 @@
+# WheelWizard Mac setup backend
+
+A self-contained .NET CLI for macOS 14+ on Apple Silicon. It implements the WheelWizard v1 NDJSON
+contract used by the Windows installer: `--version`, `--silent`, `--check-products`,
+`--repair-products`, `--launch-base`, and `--launch-retro`. Install takes `--game`, `--install-dir`,
+`--portable`, and optionally `--retro-dir` with exactly one of `--download-retro-wfc-payload` or
+`--skip-retro-wfc-payload`. Repair and check receive `--install-dir` and `--retro-dir`.
+
+The install location must be `<portable-root>/Install`. Its neighboring `Cache/BuildWorkspace`
+contains only locally extracted and translated game data. `UserData/Config.toml` is shared with
+WheelWizard and the native runtime. Native bundles sit directly in `Install` so their executable
+folders are within the runtime's four-parent portable-marker search bound.
+
+`--check-products` returns 0 for current products, 2 for required repairs, or 1 when the check fails.
+It checks installation identity, hashes the installed setup/source/tools and product bundles, checks
+runtime data paths, and fingerprints the same Retro Rewind compile inputs as the Windows installer.
+Asset-only changes do not rebuild. A repair currently runs the Mac build script for both products;
+Ninja can reuse unchanged native compilation output. This does not implement Windows' individual
+product build scheduling.
+
+Publication stages apps and the repair host beside the live installation. A journal preserves the
+previous configuration and installation until commit. The next operation recovers interrupted
+publication before checking or launching. A sibling `.mkwc-operation-macos.lock` is held for every
+operation and the full lifetime of games launched by this helper. Directly launched apps do not hold
+that lock. WheelWizard requests cooperative cancellation with `MKWCOMPILED_CANCEL_FILE`; the helper
+stops build children and returns a terminal failure before publication, while a committed operation
+reports success. WheelWizard kills the process tree if the helper does not respond within ten seconds.
+
+Build the game-code-free release asset using verified native tools:
+
+```sh
+Launcher/macos/build-wheelwizard-setup.command \
+  --tools-root '/Applications/WiiCompiled Setup.app/Contents/Resources/tools' \
+  --output Launcher/dist/WiiCompiled-Setup-macos-arm64.run
+```
+
+The builder packages only tracked source files and supplied tools. The self-extracting `.run` archive
+uses a private temporary directory, supports a fast `--version` query, and leaves a self-contained
+repair host inside the installation. It needs neither a system .NET runtime nor administrator access.
+Xcode Command Line Tools remain required to compile the user's disc locally.
+
+Validation:
+
+```sh
+dotnet test Launcher/WiiCompiled.Setup.MacOS.Tests
+```
+
+For an end-to-end test, pass a user-owned clean PAL RMCP01 disc and an installed RetroRewind6 folder
+to the setup, check products, launch through WheelWizard, and confirm the runtime uses Metal and the
+portable configuration. Online matchmaking requires a separate live test; embedding a verified
+Retro-WFC payload alone does not establish online compatibility.

--- a/Launcher/WiiCompiled.Setup.MacOS/WiiCompiled.Setup.MacOS.csproj
+++ b/Launcher/WiiCompiled.Setup.MacOS/WiiCompiled.Setup.MacOS.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>WiiCompiled.Setup.MacOS</AssemblyName>
+    <Version>0.2.27</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../WiiCompiled.Setup.Common/WiiCompiled.Setup.Common.csproj" />
+    <Compile Include="../WiiCompiled.Setup.Windows/CompileInputsFingerprint.cs" Link="CompileInputsFingerprint.cs" />
+  </ItemGroup>
+</Project>

--- a/Launcher/macos/build-wheelwizard-setup.command
+++ b/Launcher/macos/build-wheelwizard-setup.command
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Build a redistributable, self-contained WheelWizard setup asset containing source and tools only.
+set -euo pipefail
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+workspace=$(cd "$script_dir/../.." && pwd)
+tools_root=""; output=""; version=""
+while (($#)); do
+    case "$1" in
+        --tools-root) tools_root=$2; shift 2 ;;
+        --output) output=$2; shift 2 ;;
+        --version) version=${2#v}; shift 2 ;;
+        *) echo "Usage: $0 --tools-root DIR --output FILE [--version VERSION]" >&2; exit 1 ;;
+    esac
+done
+[[ -n "$output" && -d "$tools_root" ]] || { echo 'Supply --tools-root and --output' >&2; exit 1; }
+for tool in nodtool Translator.Cli ninja cmake/bin/cmake; do
+    [[ -x "$tools_root/$tool" ]] || { echo "Missing tool: $tools_root/$tool" >&2; exit 1; }
+done
+stage=$(mktemp -d "${TMPDIR:-/tmp}/wiicompiled-wheelwizard.XXXXXX")
+trap 'rm -rf "$stage"' EXIT
+version_arg=(); [[ -n "$version" ]] && version_arg=("-p:Version=$version")
+dotnet publish "$workspace/Launcher/WiiCompiled.Setup.MacOS" -c Release -r osx-arm64 --self-contained true \
+    -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true "${version_arg[@]}" -o "$stage/payload"
+version=$("$stage/payload/WiiCompiled.Setup.MacOS" --version)
+mkdir -p "$stage/payload/workspace"
+# Tracked source only: never copy ignored game extractions, generated C++, build output or local caches.
+git -C "$workspace" ls-files -z aurora-main projects runtime translator Launcher/local-build-macos.command Launcher/macos/extract-disc.command Launcher/macos/publish-app.command LICENSE THIRD-PARTY-NOTICES.md > "$stage/source-files"
+(cd "$workspace" && /usr/bin/tar --null -T "$stage/source-files" -cf -) | /usr/bin/tar -xf - -C "$stage/payload/workspace"
+DITTONORSRC=1 /usr/bin/ditto --norsrc --noqtn "$tools_root" "$stage/payload/tools"
+rm -f "$stage/payload/"*.pdb
+mkdir -p "$(dirname "$output")"
+# --version must be fast; all other operations unpack to private scratch and leave cleanup to the shell.
+cat > "$output" <<EOF_HEADER
+#!/bin/bash
+set -euo pipefail
+if [[ \$# == 1 && \$1 == --version ]]; then printf '%s\\n' '$version'; exit 0; fi
+scratch=\$(mktemp -d "\${TMPDIR:-/tmp}/wiicompiled-setup.XXXXXX")
+trap 'rm -rf "\$scratch"' EXIT
+line=\$(awk '/^__WIICOMPILED_PAYLOAD__\$/{print NR+1; exit}' "\$0")
+tail -n +"\$line" "\$0" | /usr/bin/tar -xz -C "\$scratch"
+"\$scratch/WiiCompiled.Setup.MacOS" "\$@"
+exit \$?
+__WIICOMPILED_PAYLOAD__
+EOF_HEADER
+COPYFILE_DISABLE=1 /usr/bin/tar -czf "$stage/payload.tar.gz" -C "$stage/payload" .
+cat "$stage/payload.tar.gz" >> "$output"
+chmod +x "$output"
+printf 'Created WheelWizard native setup: %s\n' "$output"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,21 @@ image under Settings, turn on **WiiCompiled (beta)**, and hit install from the H
 Wheel Wizard downloads the setup tool from this repo and walks you through install, updates and
 launching. The backend itself is deliberately command-line only, Wheel Wizard is a wrapper around it.
 
+### macOS
+
+Download `WiiCompiled-Setup.pkg` from this repository's Releases page and open it. It requires an
+Apple Silicon Mac because its bundled nodtool and Translator.Cli executables are arm64. It installs
+**WiiCompiled Setup** in Applications; open that app, choose your clean PAL `RMCP01` disc image,
+and select either the base game or Retro Rewind. For Retro Rewind, choose the `RetroRewind6` folder
+or its parent folder.
+
+Setup verifies and extracts the image locally, then translates and compiles the native app on your
+Mac. On a first run it may ask macOS to install Xcode Command Line Tools; complete Apple's installer,
+then open Setup again. When the build completes, Setup asks for administrator approval once to install
+`WiiCompiled.app` (and, if selected, `RetroRewind.app`) in `/Applications`.
+
+Setup opens Terminal while it works, so the extraction and build progress—and any error that needs
+reporting—remain visible.
 
 > [!CAUTION]
 > Only take builds from this repository's


### PR DESCRIPTION
apple silicon mac wheelwizard support in testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS installer for Apple Silicon devices running macOS 14 or later.
  * Supports installation, repair, integrity checks, cancellation, progress reporting, and recovery after interrupted operations.
  * Provides packaged `.pkg` and standalone setup assets for macOS releases.
  * Supports local extraction, compilation, game/profile selection, and optional payload preparation.
  * Added clearer handling for unsupported operating systems and architectures.

* **Documentation**
  * Added macOS installation instructions, prerequisites, application locations, and troubleshooting guidance.

* **Tests**
  * Added coverage for validation, repair detection, integrity checks, state recovery, and interrupted installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->