### PR TITLE
Reduce CI time using caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,14 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('translator/Translator.sln', '**/*.csproj', '**/*.props', '**/*.targets', '**/packages.lock.json', 'global.json', 'NuGet.config', 'nuget.config') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore
         run: dotnet restore translator/Translator.sln
 

--- a/.github/workflows/recomp-test.yml
+++ b/.github/workflows/recomp-test.yml
@@ -30,7 +30,7 @@ jobs:
 
       # Install sccache.
       - name: Run sccache-action
-        uses: mozilla/sccache-action@v0.0.8
+        uses: mozilla/sccache-action@v0.0.11
 
       # Tell CMake to use sccache and use GitHub's API.
       - name: Configure sccache environment

--- a/.github/workflows/recomp-test.yml
+++ b/.github/workflows/recomp-test.yml
@@ -37,8 +37,8 @@ jobs:
         shell: pwsh
         run: |
           "SCCACHE_GHA_ENABLED=true" | Add-Content -Path $env:GITHUB_ENV
-          "CMAKE_C_COMPILER_LAUNCHER=sccache" | Add-Content -Path $env:GITHUB_ENV
-          "CMAKE_CXX_COMPILER_LAUNCHER=sccache" | Add-Content -Path $env:GITHUB_ENV
+          "CMAKE_C_COMPILER_LAUNCHER=$env:SCCACHE_PATH" | Add-Content -Path $env:GITHUB_ENV
+          "CMAKE_CXX_COMPILER_LAUNCHER=$env:SCCACHE_PATH" | Add-Content -Path $env:GITHUB_ENV
 
       - name: Prepare the shipped Windows toolchain
         shell: pwsh
@@ -54,7 +54,7 @@ jobs:
         env:
           ACTIONS_CACHE_URL: ${{ env.ACTIONS_CACHE_URL }}
           ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}
-        run: ./Launcher/Test-Recompilation.ps1 -Parallel 2
+        run: ./Launcher/Test-Recompilation.ps1 -Parallel 3
 
       # Print cache results (even if the build fails)
       - name: Show sccache stats

--- a/.github/workflows/recomp-test.yml
+++ b/.github/workflows/recomp-test.yml
@@ -52,7 +52,7 @@ jobs:
       # Expose cache token context to the build script.
       - name: Translate, compile the full runtime, and link
         shell: pwsh
-        run: ./Launcher/Test-Recompilation.ps1
+        run: ./Launcher/Test-Recompilation.ps1 -Parallel 4
 
       # Print cache results (even if the build fails)
       - name: Show sccache stats

--- a/.github/workflows/recomp-test.yml
+++ b/.github/workflows/recomp-test.yml
@@ -37,6 +37,7 @@ jobs:
         shell: pwsh
         run: |
           "SCCACHE_GHA_ENABLED=true" | Add-Content -Path $env:GITHUB_ENV
+          "ACTIONS_CACHE_URL=$env:ACTIONS_RESULTS_URL" | Add-Content -Path $env:GITHUB_ENV
           "CMAKE_C_COMPILER_LAUNCHER=$env:SCCACHE_PATH" | Add-Content -Path $env:GITHUB_ENV
           "CMAKE_CXX_COMPILER_LAUNCHER=$env:SCCACHE_PATH" | Add-Content -Path $env:GITHUB_ENV
 
@@ -51,10 +52,7 @@ jobs:
       # Expose cache token context to the build script.
       - name: Translate, compile the full runtime, and link
         shell: pwsh
-        env:
-          ACTIONS_CACHE_URL: ${{ env.ACTIONS_CACHE_URL }}
-          ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}
-        run: ./Launcher/Test-Recompilation.ps1 -Parallel 3
+        run: ./Launcher/Test-Recompilation.ps1
 
       # Print cache results (even if the build fails)
       - name: Show sccache stats

--- a/.github/workflows/recomp-test.yml
+++ b/.github/workflows/recomp-test.yml
@@ -28,6 +28,18 @@ jobs:
           path: Launcher/artifacts/downloads
           key: windows-recomp-downloads-${{ hashFiles('Launcher/Prepare-PortableTools.ps1', 'Launcher/Prepare-Dependencies.ps1') }}
 
+      # Install sccache.
+      - name: Run sccache-action
+        uses: mozilla/sccache-action@v0.0.8
+
+      # Tell CMake to use sccache and use GitHub's API.
+      - name: Configure sccache environment
+        shell: pwsh
+        run: |
+          "SCCACHE_GHA_ENABLED=true" | Add-Content -Path $env:GITHUB_ENV
+          "CMAKE_C_COMPILER_LAUNCHER=sccache" | Add-Content -Path $env:GITHUB_ENV
+          "CMAKE_CXX_COMPILER_LAUNCHER=sccache" | Add-Content -Path $env:GITHUB_ENV
+
       - name: Prepare the shipped Windows toolchain
         shell: pwsh
         run: ./Launcher/Prepare-PortableTools.ps1
@@ -36,6 +48,16 @@ jobs:
         shell: pwsh
         run: ./Launcher/Prepare-Dependencies.ps1
 
+      # Expose cache token context to the build script.
       - name: Translate, compile the full runtime, and link
         shell: pwsh
-        run: ./Launcher/Test-Recompilation.ps1 -Parallel 3
+        env:
+          ACTIONS_CACHE_URL: ${{ env.ACTIONS_CACHE_URL }}
+          ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}
+        run: ./Launcher/Test-Recompilation.ps1 -Parallel 2
+
+      # Print cache results (even if the build fails)
+      - name: Show sccache stats
+        if: always()
+        shell: pwsh
+        run: sccache --show-stats

--- a/.github/workflows/recomp-test.yml
+++ b/.github/workflows/recomp-test.yml
@@ -37,7 +37,7 @@ jobs:
         shell: pwsh
         run: |
           "SCCACHE_GHA_ENABLED=true" | Add-Content -Path $env:GITHUB_ENV
-          "ACTIONS_CACHE_URL=$env:ACTIONS_RESULTS_URL" | Add-Content -Path $env:GITHUB_ENV
+          "ACTIONS_CACHE_SERVICE_V2=on" | Add-Content -Path $env:GITHUB_ENV
           "CMAKE_C_COMPILER_LAUNCHER=$env:SCCACHE_PATH" | Add-Content -Path $env:GITHUB_ENV
           "CMAKE_CXX_COMPILER_LAUNCHER=$env:SCCACHE_PATH" | Add-Content -Path $env:GITHUB_ENV
 

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ project.lock.json
 *.log
 output.txt
 
+# Operating System
+.DS_Store

--- a/Launcher/NativeBuildFlags.ps1
+++ b/Launcher/NativeBuildFlags.ps1
@@ -117,12 +117,13 @@ function Get-MkwProjectPins([string]$ProjectFile) {
 }
 
 function Invoke-Checked([string]$FilePath, [string[]]$Arguments, [string]$Description,
-    [string]$LogPrefix = 'MKWCBUILD', [string]$StepId = '') {
+    [string]$LogPrefix = 'MKWCBUILD', [string]$StepId = '', [bool]$WaitForProcessTree = $true) {
     <#
-    Runs a build tool and turns a non-zero exit code into a described failure. Start-Process -Wait
-    is deliberate: it waits for the whole process tree, since a .NET single-file bundle host may
-    hand off to an extracted child that PowerShell's call operator would not wait for. Start-Process
-    doesn't publish $LASTEXITCODE, so this sets it manually for callers that check it.
+    Runs a build tool and turns a non-zero exit code into a described failure. By default,
+    Start-Process -Wait waits for the whole process tree, since a .NET single-file bundle host may
+    hand off to an extracted child that PowerShell's call operator would not wait for. Callers that
+    need to avoid waiting on unrelated descendants can opt into the call-operator path.
+    Start-Process doesn't publish $LASTEXITCODE, so this sets it manually for callers that check it.
     -StepId emits the machine-readable form the installer's progress bar consumes (BuildStepIds in
     WiiCompiled.Setup/InstallProgress.cs); the human sentence stays on the same log line.
     #>
@@ -132,9 +133,14 @@ function Invoke-Checked([string]$FilePath, [string[]]$Arguments, [string]$Descri
         if ($_.Contains('"')) { throw "A native build argument contains an unsupported quote: $_" }
         '"' + $_ + '"'
     })
-    $process = Start-Process -FilePath $FilePath -ArgumentList $quotedArguments `
-        -NoNewWindow -Wait -PassThru
-    $exitCode = $process.ExitCode
+    if ($WaitForProcessTree) {
+        $process = Start-Process -FilePath $FilePath -ArgumentList $quotedArguments `
+            -NoNewWindow -Wait -PassThru
+        $exitCode = $process.ExitCode
+    } else {
+        & $FilePath @Arguments
+        $exitCode = $LASTEXITCODE
+    }
     $global:LASTEXITCODE = $exitCode
     if ($exitCode -ne 0) { throw "$Description failed with exit code $exitCode." }
 }

--- a/Launcher/Test-Recompilation.ps1
+++ b/Launcher/Test-Recompilation.ps1
@@ -136,9 +136,11 @@ try {
         -CxxCompiler (Join-Path $compilerBin 'x86_64-w64-mingw32-clang++.exe') `
         -ResourceCompiler (Join-Path $compilerBin 'x86_64-w64-mingw32-windres.exe') `
         -DependenciesDirectory $dependencies -AdditionalArguments @('-DMKW_BUILD_PRODUCTS=ON')
-    Invoke-Checked $cmake $configure 'Configuring the production Windows runtime'
+    Invoke-Checked $cmake $configure 'Configuring the production Windows runtime' `
+        -WaitForProcessTree $false
     Invoke-Checked $cmake @('--build', $nativeBuild, '--target', 'WiiCompiled', '--parallel', "$Parallel") `
-        'Compiling and linking the synthetic product with the full runtime'
+        'Compiling and linking the synthetic product with the full runtime' `
+        -WaitForProcessTree $false
     Assert-File (Join-Path $nativeBuild 'WiiCompiled.exe') 'Linked synthetic product'
 } finally {
     $env:PATH = $oldPath


### PR DESCRIPTION
I saw the compilation step takes ~8 minutes, just trying some tricks to bring that down. 

TL;DR added compiler and NuGet caching. 
- `sccache` for the Windows runtime build, which made me have to remove some unnecessary waits in the scripts.
-   NuGet packages now get cached between runs, so unchanged .NET dependencies aren't re-downloaded.