### PR TITLE
os_sleep: process due sleep timers one at a time so parked threads aren't stranded

### DIFF
--- a/runtime/src/hle/os/os_sleep.cpp
+++ b/runtime/src/hle/os/os_sleep.cpp
@@ -78,22 +78,38 @@ bool ProcessSleepTimers(CpuContext* cpu)
 {
     using Clock = std::chrono::steady_clock;
 
-    std::vector<SleepTimerEntry> dueTimers;
+    // Pop and process ONE due timer at a time, straight from the shared table. Resuming a
+    // sleeper re-enters the scheduler (OSResumeThread -> SelectThread) and can switch fibers
+    // away from this call. Timers that had already been popped into a private list would then
+    // sit on the suspended fiber's stack with their threads parked and no entry in the table:
+    // exactly the "park-shaped with no pending wake timer" strand the reconciler below heals
+    // 100ms late, followed by a "sleep-timer stale" drop when this fiber finally resumes.
+    // Leaving unprocessed timers in the table keeps them visible to every other pump (idle
+    // loop, other threads' SelectThread) while this one is switched away.
+    bool processedAny = false;
+    constexpr size_t kMaxTimersPerCall = 64;
+    size_t processedCount = 0;
     const auto now = Clock::now();
-    {
-        std::lock_guard<std::mutex> lock(gSleepTimerMutex);
-        auto it = gSleepTimers.begin();
-        while (it != gSleepTimers.end()) {
-            if (it->deadline > now) {
-                ++it;
-                continue;
+    while (processedCount < kMaxTimersPerCall) {
+        SleepTimerEntry timer{0, {}};
+        bool found = false;
+        {
+            std::lock_guard<std::mutex> lock(gSleepTimerMutex);
+            for (auto it = gSleepTimers.begin(); it != gSleepTimers.end(); ++it) {
+                if (it->deadline <= now) {
+                    timer = *it;
+                    gSleepTimers.erase(it);
+                    found = true;
+                    break;
+                }
             }
-            dueTimers.push_back(*it);
-            it = gSleepTimers.erase(it);
         }
-    }
+        if (!found) {
+            break;
+        }
+        ++processedCount;
+        processedAny = true;
 
-    for (const SleepTimerEntry& timer : dueTimers) {
         const uint32_t threadPtr = timer.threadPtr;
         if (threadPtr == 0 ||
             !Memory::Contains(threadPtr + kThreadSuspendOffset, sizeof(uint32_t))) {
@@ -219,7 +235,7 @@ bool ProcessSleepTimers(CpuContext* cpu)
         }
     }
 
-    return !dueTimers.empty();
+    return processedAny;
 }
 } // namespace OsHleInternal
 


### PR DESCRIPTION
## What

`ProcessSleepTimers` in `runtime/src/hle/os/os_sleep.cpp` used to pull every due timer out of `gSleepTimers` into a local `dueTimers` vector and then resume the sleepers in a loop. This change pops one due timer at a time straight from the shared table and handles it before looking for the next. Nothing else in the function changes (the Running re-push, the stale drop and the reconciler are untouched).

## Why

Resuming a sleeper calls `OSResumeThread_HLE_801aa58c`, which re-enters `SelectThread` and can switch fibers away in the middle of that loop. Any timer still sitting in the local vector at that point is already erased from `gSleepTimers` but hasn't been handled, so its thread stays parked (Ready, suspended, no timer on record) until the strand reconciler force-resumes it 100ms later. When the original fiber finally gets switched back, the loop continues and logs the leftover as `sleep-timer stale`.

That is exactly the pair I was seeing in the runtime log, dozens of times a day, almost always on the default thread:

```
[os] reconciler: thread 0x80347498 park-shaped with no pending wake timer for 100ms; resuming lost sleeper
[os] sleep-timer stale for thread 0x80347498 (state=1 suspends=0); dropped without consuming a suspension
```

Online that thread stall is a ~100ms freeze of the game loop, and on my setup (Retro Rewind profile, v0.2.31, Ryzen 9950X / RTX 5060 Ti, wired) it came with frequent error 91010 room disconnects. Dolphin with the same Retro Rewind pack on the same connection had none, and there were no host socket failures in the log.

Keeping unprocessed timers in the table means any other pump (the idle loop in `SelectThread`, another thread's scheduling call) can pick them up while this call is switched away, which is what the reconciler was compensating for. The reconciler stays as a safety net.

## Testing

- Before: 51 strands of the default thread and 74 total in one day of play (Sept 7), each paired with a stale drop.
- After (patched RetroRewind.exe built with the shipped LocalBuild.ps1): 0 strands, 0 stale drops and no disconnects across roughly 6 hours of online play over two days.
- `WiiCompiled-Setup.exe --check-products` reports both products current.

Cap of 64 timers per call is there so a pathological table can't spin this loop forever; in practice a handful are due at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sleep-timer processing when waking tasks causes scheduler switches.
  - Ensured pending timers remain available for subsequent processing instead of becoming stranded.
  - Limited each processing pass to 64 timers to improve scheduler responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->