### PR TITLE
[Linux] Handle NAND moves across mount points

### DIFF
--- a/runtime/src/hle/storage/nand_api.cpp
+++ b/runtime/src/hle/storage/nand_api.cpp
@@ -5,6 +5,12 @@
 #include "nand_internal.h"
 
 #include <atomic>
+#include <cerrno>
+
+#ifdef __linux__
+#include <linux/fs.h>
+#include <sys/syscall.h>
+#endif
 
 // ============================================================================
 // Local helpers
@@ -45,6 +51,32 @@ static FileHandle* ResolveNandFileHandle(const char* who, uint32_t fileInfoPtr) 
 // ============================================================================
 // The synchronous RVL NAND* library
 // ============================================================================
+
+static bool RenameNoReplace(const std::filesystem::path& from,
+                            const std::filesystem::path& to,
+                            std::error_code& error) {
+#ifdef _WIN32
+    if (MoveFileExW(from.c_str(), to.c_str(), MOVEFILE_WRITE_THROUGH)) {
+        error.clear();
+        return true;
+    }
+    error = std::error_code(static_cast<int>(GetLastError()), std::system_category());
+    return false;
+#elif defined(__linux__)
+    const int result = syscall(SYS_renameat2, AT_FDCWD, from.c_str(), AT_FDCWD, to.c_str(), RENAME_NOREPLACE);
+    if (result == 0) {
+        error.clear();
+        return true;
+    }
+    error = std::error_code(errno, std::generic_category());
+    return false;
+#else
+    (void)from;
+    (void)to;
+    error = std::make_error_code(std::errc::operation_not_supported);
+    return false;
+#endif
+}
 
 extern "C" int32_t NANDInit_HLE(void) {
     // Initialize ISFS
@@ -450,21 +482,8 @@ extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
         }
 
         std::error_code publishEc;
-        bool destinationClaimed = false;
         if (sourceIsDirectory) {
-            destinationClaimed = std::filesystem::create_directory(dstHost, publishEc);
-            if (!destinationClaimed && !publishEc) {
-                publishEc = std::make_error_code(std::errc::file_exists);
-            }
-            if (!publishEc) {
-                for (const auto& entry : std::filesystem::directory_iterator(tempHost, publishEc)) {
-                    if (publishEc) {
-                        break;
-                    }
-                    std::filesystem::copy(entry.path(), dstHost / entry.path().filename(),
-                                          std::filesystem::copy_options::recursive, publishEc);
-                }
-            }
+            RenameNoReplace(tempHost, dstHost, publishEc);
         } else {
             // link(2) and CreateHardLink do not replace an existing destination,
             // unlike rename(2) on POSIX. Both paths are already on the target
@@ -474,14 +493,6 @@ extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
         if (publishEc) {
             LogNandError("NANDMove", "failed to publish cross-mount copy: %s",
                          publishEc.message().c_str());
-            if (destinationClaimed) {
-                std::error_code rollbackEc;
-                std::filesystem::remove_all(dstHost, rollbackEc);
-                if (rollbackEc) {
-                    LogNandError("NANDMove", "failed to remove partial destination '%s': %s",
-                                 HostPathText(dstHost).c_str(), rollbackEc.message().c_str());
-                }
-            }
             cleanupScratch();
             return NAND_RESULT_UNKNOWN;
         }

--- a/runtime/src/hle/storage/nand_api.cpp
+++ b/runtime/src/hle/storage/nand_api.cpp
@@ -4,6 +4,8 @@
 
 #include "nand_internal.h"
 
+#include <atomic>
+
 // ============================================================================
 // Local helpers
 // ============================================================================
@@ -393,23 +395,46 @@ extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
     // nandMove must still work for files such as banner.bin. Preserve the
     // operation's semantics with a copy followed by source removal.
     if (ec == std::errc::cross_device_link) {
-        std::filesystem::path tempHost = dstHost;
-        tempHost += ".nandmove.tmp";
-        if (PathExists(tempHost)) {
-            // The source is still authoritative after an interrupted copy, so
-            // a stale temporary destination can be safely discarded.
-            std::error_code staleEc;
-            std::filesystem::remove_all(tempHost, staleEc);
-            if (staleEc) {
-                LogNandError("NANDMove", "failed to remove stale temporary path '%s': %s",
-                             HostPathText(tempHost).c_str(), staleEc.message().c_str());
+        static std::atomic<uint64_t> moveSequence{0};
+#ifdef _WIN32
+        const auto processId = GetCurrentProcessId();
+#else
+        const auto processId = getpid();
+#endif
+        std::filesystem::path scratchHost;
+        std::error_code scratchEc;
+        for (unsigned attempt = 0; attempt < 128; ++attempt) {
+            const auto name = ".nandmove-" + std::to_string(processId) + "-" +
+                              std::to_string(moveSequence.fetch_add(1)) + "-" +
+                              std::to_string(attempt);
+            const auto candidate = dstDirectoryHost / name;
+            scratchEc.clear();
+            if (std::filesystem::create_directory(candidate, scratchEc)) {
+                scratchHost = candidate;
+                break;
+            }
+            if (scratchEc && scratchEc != std::errc::file_exists) {
+                LogNandError("NANDMove", "failed to claim temporary directory '%s': %s",
+                             HostPathText(candidate).c_str(), scratchEc.message().c_str());
                 return NAND_RESULT_UNKNOWN;
             }
-            LogNandWarning("NANDMove", "discarded stale cross-mount temporary path '%s'",
-                           HostPathText(tempHost).c_str());
+        }
+        if (scratchHost.empty()) {
+            LogNandError("NANDMove", "could not claim a unique temporary directory");
+            return NAND_RESULT_UNKNOWN;
         }
 
         const bool sourceIsDirectory = IsDirectory(srcHost);
+        const std::filesystem::path tempHost = scratchHost / srcName;
+        const auto cleanupScratch = [&]() {
+            std::error_code cleanupEc;
+            std::filesystem::remove_all(scratchHost, cleanupEc);
+            if (cleanupEc) {
+                LogNandError("NANDMove", "failed to clean up temporary directory '%s': %s",
+                             HostPathText(scratchHost).c_str(), cleanupEc.message().c_str());
+            }
+        };
+
         std::error_code copyEc;
         if (sourceIsDirectory) {
             std::filesystem::copy(srcHost, tempHost,
@@ -419,29 +444,43 @@ extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
         }
 
         if (copyEc) {
-            std::error_code cleanupEc;
-            std::filesystem::remove_all(tempHost, cleanupEc);
             LogNandError("NANDMove", "cross-mount copy failed: %s", copyEc.message().c_str());
-            if (cleanupEc) {
-                LogNandError("NANDMove", "failed to clean up temporary path '%s': %s",
-                             HostPathText(tempHost).c_str(), cleanupEc.message().c_str());
-            }
+            cleanupScratch();
             return NAND_RESULT_UNKNOWN;
         }
 
         std::error_code publishEc;
-        std::filesystem::rename(tempHost, dstHost, publishEc);
+        bool destinationClaimed = false;
+        if (sourceIsDirectory) {
+            destinationClaimed = std::filesystem::create_directory(dstHost, publishEc);
+            if (!destinationClaimed && !publishEc) {
+                publishEc = std::make_error_code(std::errc::file_exists);
+            }
+            if (!publishEc) {
+                std::filesystem::copy(tempHost, dstHost,
+                                      std::filesystem::copy_options::recursive, publishEc);
+            }
+        } else {
+            // link(2) and CreateHardLink do not replace an existing destination,
+            // unlike rename(2) on POSIX. Both paths are already on the target
+            // filesystem, so the link is a no-replace publication operation.
+            std::filesystem::create_hard_link(tempHost, dstHost, publishEc);
+        }
         if (publishEc) {
-            std::error_code cleanupEc;
-            std::filesystem::remove_all(tempHost, cleanupEc);
             LogNandError("NANDMove", "failed to publish cross-mount copy: %s",
                          publishEc.message().c_str());
-            if (cleanupEc) {
-                LogNandError("NANDMove", "failed to clean up temporary path '%s': %s",
-                             HostPathText(tempHost).c_str(), cleanupEc.message().c_str());
+            if (destinationClaimed) {
+                std::error_code rollbackEc;
+                std::filesystem::remove_all(dstHost, rollbackEc);
+                if (rollbackEc) {
+                    LogNandError("NANDMove", "failed to remove partial destination '%s': %s",
+                                 HostPathText(dstHost).c_str(), rollbackEc.message().c_str());
+                }
             }
+            cleanupScratch();
             return NAND_RESULT_UNKNOWN;
         }
+        cleanupScratch();
 
         std::error_code removeEc;
         std::filesystem::remove_all(srcHost, removeEc);

--- a/runtime/src/hle/storage/nand_api.cpp
+++ b/runtime/src/hle/storage/nand_api.cpp
@@ -451,9 +451,10 @@ extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
         }
 
         // Keep the source as the authoritative copy when cleanup fails. The
-        // destination was published atomically on its own mount, so remove it
-        // to avoid presenting two entries to a later NAND scan. Cross-mount
-        // moves cannot provide crash-atomicity, so this is best effort.
+        // destination was published atomically on its own mount; regular files
+        // are rolled back below, while directories keep the complete copy when
+        // their source removal was only partial. Cross-mount moves cannot
+        // provide crash-atomicity, so this is best effort.
         LogNandError("NANDMove", "copy succeeded but source removal failed: %s",
                      removeEc.message().c_str());
         if (sourceIsDirectory) {

--- a/runtime/src/hle/storage/nand_api.cpp
+++ b/runtime/src/hle/storage/nand_api.cpp
@@ -383,6 +383,33 @@ extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
         return NAND_RESULT_OK;
     }
 
+    // Flatpak can expose the managed NAND and an external Riivolution save
+    // directory as separate mounts. Linux cannot rename across mounts, but
+    // nandMove must still work for files such as banner.bin. Preserve the
+    // operation's semantics with a copy followed by source removal.
+    if (ec == std::make_error_code(std::errc::cross_device_link)) {
+        std::error_code copyEc;
+        if (IsDirectory(srcHost)) {
+            std::filesystem::copy(srcHost, dstHost,
+                                  std::filesystem::copy_options::recursive, copyEc);
+        } else {
+            std::filesystem::copy_file(srcHost, dstHost, copyEc);
+        }
+
+        if (!copyEc) {
+            std::error_code removeEc;
+            std::filesystem::remove_all(srcHost, removeEc);
+            if (!removeEc) {
+                LogNandWarning("NANDMove", "used copy/remove fallback across mounts");
+                return NAND_RESULT_OK;
+            }
+            LogNandError("NANDMove", "copy succeeded but source removal failed: %s",
+                         removeEc.message().c_str());
+        } else {
+            LogNandError("NANDMove", "cross-mount copy failed: %s", copyEc.message().c_str());
+        }
+    }
+
     LogNandError("NANDMove", "FAILED error=%d message='%s'", ec.value(), ec.message().c_str());
     return NAND_RESULT_UNKNOWN;
 }

--- a/runtime/src/hle/storage/nand_api.cpp
+++ b/runtime/src/hle/storage/nand_api.cpp
@@ -457,8 +457,13 @@ extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
                 publishEc = std::make_error_code(std::errc::file_exists);
             }
             if (!publishEc) {
-                std::filesystem::copy(tempHost, dstHost,
-                                      std::filesystem::copy_options::recursive, publishEc);
+                for (const auto& entry : std::filesystem::directory_iterator(tempHost, publishEc)) {
+                    if (publishEc) {
+                        break;
+                    }
+                    std::filesystem::copy(entry.path(), dstHost / entry.path().filename(),
+                                          std::filesystem::copy_options::recursive, publishEc);
+                }
             }
         } else {
             // link(2) and CreateHardLink do not replace an existing destination,

--- a/runtime/src/hle/storage/nand_api.cpp
+++ b/runtime/src/hle/storage/nand_api.cpp
@@ -409,8 +409,9 @@ extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
                            HostPathText(tempHost).c_str());
         }
 
+        const bool sourceIsDirectory = IsDirectory(srcHost);
         std::error_code copyEc;
-        if (IsDirectory(srcHost)) {
+        if (sourceIsDirectory) {
             std::filesystem::copy(srcHost, tempHost,
                                   std::filesystem::copy_options::recursive, copyEc);
         } else {
@@ -453,13 +454,20 @@ extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
         // destination was published atomically on its own mount, so remove it
         // to avoid presenting two entries to a later NAND scan. Cross-mount
         // moves cannot provide crash-atomicity, so this is best effort.
-        std::error_code rollbackEc;
-        std::filesystem::remove_all(dstHost, rollbackEc);
         LogNandError("NANDMove", "copy succeeded but source removal failed: %s",
                      removeEc.message().c_str());
-        if (rollbackEc) {
-            LogNandError("NANDMove", "failed to roll back destination '%s': %s",
-                         HostPathText(dstHost).c_str(), rollbackEc.message().c_str());
+        if (sourceIsDirectory) {
+            // remove_all may have removed only part of a directory tree. Keep
+            // the complete published copy rather than rolling it back to a
+            // partially deleted source.
+            LogNandWarning("NANDMove", "preserving published directory copy after partial source removal");
+        } else {
+            std::error_code rollbackEc;
+            std::filesystem::remove_all(dstHost, rollbackEc);
+            if (rollbackEc) {
+                LogNandError("NANDMove", "failed to roll back destination '%s': %s",
+                             HostPathText(dstHost).c_str(), rollbackEc.message().c_str());
+            }
         }
         return NAND_RESULT_UNKNOWN;
     }

--- a/runtime/src/hle/storage/nand_api.cpp
+++ b/runtime/src/hle/storage/nand_api.cpp
@@ -348,6 +348,11 @@ extern "C" int32_t NANDCreateDir_HLE(uint32_t pathPtr, uint32_t perm, uint32_t a
 PPC_NATIVE_OVERRIDE(8019BBE0, NANDCreateDir_HLE, int32_t, (uint32_t pathPtr, uint32_t perm, uint32_t attr), (pathPtr, perm, attr));
 
 extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
+    // A cross-mount move is implemented as several host operations. Keep two
+    // guest moves from interleaving those operations and corrupting recovery.
+    static std::mutex moveMutex;
+    std::lock_guard<std::mutex> lock(moveMutex);
+
     const char* srcPath = srcPathPtr ? (const char*)Memory::GetPointer(srcPathPtr) : nullptr;
     const char* dstPath = dstPathPtr ? (const char*)Memory::GetPointer(dstPathPtr) : nullptr;
     
@@ -387,27 +392,76 @@ extern "C" int32_t NANDMove_HLE(uint32_t srcPathPtr, uint32_t dstPathPtr) {
     // directory as separate mounts. Linux cannot rename across mounts, but
     // nandMove must still work for files such as banner.bin. Preserve the
     // operation's semantics with a copy followed by source removal.
-    if (ec == std::make_error_code(std::errc::cross_device_link)) {
-        std::error_code copyEc;
-        if (IsDirectory(srcHost)) {
-            std::filesystem::copy(srcHost, dstHost,
-                                  std::filesystem::copy_options::recursive, copyEc);
-        } else {
-            std::filesystem::copy_file(srcHost, dstHost, copyEc);
+    if (ec == std::errc::cross_device_link) {
+        std::filesystem::path tempHost = dstHost;
+        tempHost += ".nandmove.tmp";
+        if (PathExists(tempHost)) {
+            // The source is still authoritative after an interrupted copy, so
+            // a stale temporary destination can be safely discarded.
+            std::error_code staleEc;
+            std::filesystem::remove_all(tempHost, staleEc);
+            if (staleEc) {
+                LogNandError("NANDMove", "failed to remove stale temporary path '%s': %s",
+                             HostPathText(tempHost).c_str(), staleEc.message().c_str());
+                return NAND_RESULT_UNKNOWN;
+            }
+            LogNandWarning("NANDMove", "discarded stale cross-mount temporary path '%s'",
+                           HostPathText(tempHost).c_str());
         }
 
-        if (!copyEc) {
-            std::error_code removeEc;
-            std::filesystem::remove_all(srcHost, removeEc);
-            if (!removeEc) {
-                LogNandWarning("NANDMove", "used copy/remove fallback across mounts");
-                return NAND_RESULT_OK;
-            }
-            LogNandError("NANDMove", "copy succeeded but source removal failed: %s",
-                         removeEc.message().c_str());
+        std::error_code copyEc;
+        if (IsDirectory(srcHost)) {
+            std::filesystem::copy(srcHost, tempHost,
+                                  std::filesystem::copy_options::recursive, copyEc);
         } else {
-            LogNandError("NANDMove", "cross-mount copy failed: %s", copyEc.message().c_str());
+            std::filesystem::copy_file(srcHost, tempHost, copyEc);
         }
+
+        if (copyEc) {
+            std::error_code cleanupEc;
+            std::filesystem::remove_all(tempHost, cleanupEc);
+            LogNandError("NANDMove", "cross-mount copy failed: %s", copyEc.message().c_str());
+            if (cleanupEc) {
+                LogNandError("NANDMove", "failed to clean up temporary path '%s': %s",
+                             HostPathText(tempHost).c_str(), cleanupEc.message().c_str());
+            }
+            return NAND_RESULT_UNKNOWN;
+        }
+
+        std::error_code publishEc;
+        std::filesystem::rename(tempHost, dstHost, publishEc);
+        if (publishEc) {
+            std::error_code cleanupEc;
+            std::filesystem::remove_all(tempHost, cleanupEc);
+            LogNandError("NANDMove", "failed to publish cross-mount copy: %s",
+                         publishEc.message().c_str());
+            if (cleanupEc) {
+                LogNandError("NANDMove", "failed to clean up temporary path '%s': %s",
+                             HostPathText(tempHost).c_str(), cleanupEc.message().c_str());
+            }
+            return NAND_RESULT_UNKNOWN;
+        }
+
+        std::error_code removeEc;
+        std::filesystem::remove_all(srcHost, removeEc);
+        if (!removeEc) {
+            LogNandWarning("NANDMove", "used copy/remove fallback across mounts");
+            return NAND_RESULT_OK;
+        }
+
+        // Keep the source as the authoritative copy when cleanup fails. The
+        // destination was published atomically on its own mount, so remove it
+        // to avoid presenting two entries to a later NAND scan. Cross-mount
+        // moves cannot provide crash-atomicity, so this is best effort.
+        std::error_code rollbackEc;
+        std::filesystem::remove_all(dstHost, rollbackEc);
+        LogNandError("NANDMove", "copy succeeded but source removal failed: %s",
+                     removeEc.message().c_str());
+        if (rollbackEc) {
+            LogNandError("NANDMove", "failed to roll back destination '%s': %s",
+                         HostPathText(dstHost).c_str(), rollbackEc.message().c_str());
+        }
+        return NAND_RESULT_UNKNOWN;
     }
 
     LogNandError("NANDMove", "FAILED error=%d message='%s'", ec.value(), ec.message().c_str());


### PR DESCRIPTION
## Context

On Linux Flatpak installs, Wheel Wizard can redirect a Retro Rewind save into Dolphin's Flatpak data directory. WiiCompiled's managed NAND and that directory are separate mounts inside the sandbox.

When Mario Kart Wii calls `nandMove` for a file such as `banner.bin`, the host `std::filesystem::rename` returns `EXDEV` (`Invalid cross-device link`). The game surfaces that failed NAND operation as its generic Wii system-memory error.

## Change

- Keep the existing atomic `rename` path for normal same-mount moves.
- On `cross_device_link`, copy the file or directory to a temporary path on the destination mount.
- Publish the temporary path on that mount, then remove the source.
- Clean up failed copies and stale temporary paths.
- Preserve a complete published directory copy if recursive source cleanup is only partial.

The fallback is serialized and reports failures instead of treating a partial move as successful. Cross-mount moves cannot be fully crash-atomic, so this path remains best effort by necessity.

## Validation

- Reproduced the original failure with Wheel Wizard 2.5.5 Flatpak on Fedora Asahi Linux ARM64; the log contained `NANDMove: FAILED error=18 message='Invalid cross-device link'`.
- Rebuilt the ARM64 Retro Rewind product through the Wheel Wizard setup path with this change.
- Relaunched in the same Flatpak environment; the log now reports `NANDMove: used copy/remove fallback across mounts` and no longer reports the `EXDEV` failure.
- Ran a Clang C++20 syntax check on `runtime/src/hle/storage/nand_api.cpp`.
- `git diff --check` passes.

No Nintendo code, assets, or game data are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when moving stored data between different filesystems.
  - Added safer recovery when a move cannot be completed, helping prevent data loss and preserving the original data where possible.
  - Improved handling of interrupted, incomplete, or stale temporary move operations.
  - Improved directory move handling to avoid partial destinations.
  - Ensured simultaneous move operations are processed safely.
  - Improved error reporting and cleanup when moving files or directories fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->