### PR TITLE
switch to dawn-build fork building on Ubuntu 22.04 rather than 24.04 …

### DIFF
--- a/Launcher/Prepare-Dependencies.ps1
+++ b/Launcher/Prepare-Dependencies.ps1
@@ -39,9 +39,9 @@ $packages = @(
     },
     [pscustomobject]@{
         Name = 'dawn_prebuilt'; File = 'dawn-v20260603.191052-windows-amd64.tar.gz'
-        Uris = @('https://github.com/encounter/dawn-build/releases/download/v20260603.191052/dawn-windows-amd64.tar.gz')
+        Uris = @('https://github.com/theofficialgman/dawn-build/releases/download/v20260603.191052/dawn-windows-amd64.tar.gz')
         Pins = @(@{ File = $auroraCMake; Text = 'set(AURORA_DAWN_VERSION "v20260603.191052"' },
-                 @{ File = $auroraDawn; Text = 'SHA256=7785373d569b3b0237918ec9c523239f7d0667857c5ea8242e3cdfde95e6aeab' })
+                 @{ File = $auroraDawn; Text = 'SHA256=13be9cff8b9b179c42dcd16aeabb6effcc8f0dfdcc14463eda2a5caeda225142' })
     },
     [pscustomobject]@{
         Name = 'fmt'; File = 'fmt-11.1.4.tar.gz'

--- a/aurora-main/cmake/AuroraDawnProvider.cmake
+++ b/aurora-main/cmake/AuroraDawnProvider.cmake
@@ -151,15 +151,36 @@ elseif (_aurora_dawn_provider STREQUAL "package")
       endif ()
     endif ()
     set(AURORA_DAWN_PACKAGE_URL
-      "https://github.com/encounter/dawn-build/releases/download/${AURORA_DAWN_VERSION}/dawn-${_dawn_system}-${_dawn_arch}.tar.gz")
+      "https://github.com/theofficialgman/dawn-build/releases/download/${AURORA_DAWN_VERSION}/dawn-${_dawn_system}-${_dawn_arch}.tar.gz")
 
     # A release asset is mutable: the same tag has already served two different windows-amd64 archives,
     # and a cached extraction is never re-verified. Pin the digest for the combinations we ship.
-    if (NOT AURORA_DAWN_PACKAGE_URL_HASH
-        AND AURORA_DAWN_VERSION STREQUAL "v20260603.191052"
-        AND _dawn_system STREQUAL "windows" AND _dawn_arch STREQUAL "amd64")
-      set(AURORA_DAWN_PACKAGE_URL_HASH
-        "SHA256=7785373d569b3b0237918ec9c523239f7d0667857c5ea8242e3cdfde95e6aeab")
+    if (NOT AURORA_DAWN_PACKAGE_URL_HASH AND AURORA_DAWN_VERSION STREQUAL "v20260603.191052")
+      if (_dawn_system STREQUAL "windows" AND _dawn_arch STREQUAL "amd64")
+        set(AURORA_DAWN_PACKAGE_URL_HASH
+          "SHA256=13be9cff8b9b179c42dcd16aeabb6effcc8f0dfdcc14463eda2a5caeda225142")
+      elseif (_dawn_system STREQUAL "windows" AND _dawn_arch STREQUAL "arm64")
+        set(AURORA_DAWN_PACKAGE_URL_HASH
+          "SHA256=bf2d921110f14a1d6553f673c5597988e66c02af5587e4a1fee167937d247734")
+      elseif (_dawn_system STREQUAL "linux" AND _dawn_arch STREQUAL "x86_64")
+        set(AURORA_DAWN_PACKAGE_URL_HASH
+          "SHA256=7adcf241bb2a24ec0c576609f2d67203e0e65db9c5a286ca2bbb6281fa644b35")
+      elseif (_dawn_system STREQUAL "linux" AND _dawn_arch STREQUAL "aarch64")
+        set(AURORA_DAWN_PACKAGE_URL_HASH
+          "SHA256=2415e253d46f91b2d72fc73bf6055fb31b98b67c773dc546e1991b1cf019732f")
+      elseif (_dawn_system STREQUAL "darwin" AND _dawn_arch STREQUAL "arm64")
+        set(AURORA_DAWN_PACKAGE_URL_HASH
+          "SHA256=0a8ea8eb0159fc0ba1083c52155d9376fb173cffe690b400464a6ad8881bb461")
+      elseif (_dawn_system STREQUAL "darwin" AND _dawn_arch STREQUAL "x86_64")
+        set(AURORA_DAWN_PACKAGE_URL_HASH
+          "SHA256=5fe2c7a2a8b4cb82acee4af16779a83ae333c7657b9dc1a5008f5fd1f5ad5f80")
+      elseif (_dawn_system STREQUAL "ios" AND _dawn_arch STREQUAL "arm64")
+        set(AURORA_DAWN_PACKAGE_URL_HASH
+          "SHA256=f97701d26fd1f25bbcc260b4c31736ede134c730c12556029e2470fde967f424")
+      elseif (_dawn_system STREQUAL "android" AND _dawn_arch STREQUAL "aarch64")
+        set(AURORA_DAWN_PACKAGE_URL_HASH
+          "SHA256=0e63e8cbf53551f703f582d1306f4257c0380353f66b53369d96952ce6d9f934")
+      endif ()
     endif ()
   endif ()
   message(STATUS "aurora: Fetching prebuilt Dawn package from ${AURORA_DAWN_PACKAGE_URL}")


### PR DESCRIPTION
…runners

fixes https://github.com/patchzyy/Wiicompiled/issues/159 previous requirement for ubuntu 24.04+ libstdc++ inherited from dawn prebuilds now dropped to ubuntu 22.04+ libstdc++ like the rest of the prebuilds

also add all architectures to the URL_HASH check since the dawn tag doesn't change but the binaries have

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the source used to obtain prebuilt Dawn packages.
  - Added default integrity verification for supported Windows, Linux, macOS, iOS, and Android architecture combinations when no custom value is provided.
  - Updated Windows package verification to match the current archive source.
  - Improved consistency and verification of platform-specific package downloads for the current Dawn release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->